### PR TITLE
[feat] ISA 절세 계산 배치 작업 구현 및 오류 수정 완료

### DIFF
--- a/src/main/java/woojooin/planitbatch/batch/job/BatchConfig.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/BatchConfig.java
@@ -10,13 +10,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
 @EnableBatchProcessing
+@RequiredArgsConstructor
 public class BatchConfig {
-	@Autowired
-	private JobBuilderFactory jobs;
-	@Autowired
-	private StepBuilderFactory steps;
+
+	private final JobBuilderFactory jobs;
+
+	private final StepBuilderFactory steps;
 
 	@Bean
 	public Step sampleStep() {

--- a/src/main/java/woojooin/planitbatch/batch/job/IsaTaxSavingJobConfig.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/IsaTaxSavingJobConfig.java
@@ -1,0 +1,49 @@
+package woojooin.planitbatch.batch.job;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.step.tasklet.TaskletStep;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import woojooin.planitbatch.batch.processor.IsaTaxSavingProcessor;
+import woojooin.planitbatch.batch.reader.IsaTaxSavingReader;
+import woojooin.planitbatch.batch.writer.IsaTaxSavingWriter;
+import woojooin.planitbatch.domain.dto.UserProductQuarterData;
+import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableBatchProcessing
+public class IsaTaxSavingJobConfig {
+
+	private final JobBuilderFactory jobBuilderFactory;
+	private final StepBuilderFactory stepBuilderFactory;
+	private final IsaTaxSavingReader reader;
+	private final IsaTaxSavingProcessor processor;
+	private final IsaTaxSavingWriter writer;
+
+	@Bean
+	public Job isaTaxSavingJob(@Qualifier("isaTaxReader") ItemReader<UserProductQuarterData> reader) {
+		Step isaTaxSavingStep = stepBuilderFactory.get("isaTaxSavingStep")
+			.<UserProductQuarterData, IsaTaxSavingHistoryVo>chunk(100)
+			.reader(reader)
+			.processor(processor)
+			.writer(writer)
+			.build();
+
+		return jobBuilderFactory.get("isaTaxSavingJob")
+			.start(isaTaxSavingStep)
+			.build();
+	}
+
+
+
+}

--- a/src/main/java/woojooin/planitbatch/batch/job/IsaTaxSavingJobConfig.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/IsaTaxSavingJobConfig.java
@@ -21,7 +21,6 @@ import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
 
 @Configuration
 @RequiredArgsConstructor
-@EnableBatchProcessing
 public class IsaTaxSavingJobConfig {
 
 	private final JobBuilderFactory jobBuilderFactory;

--- a/src/main/java/woojooin/planitbatch/batch/job/IsaTaxSavingJobConfig.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/IsaTaxSavingJobConfig.java
@@ -2,16 +2,13 @@ package woojooin.planitbatch.batch.job;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
-import org.springframework.batch.core.step.tasklet.TaskletStep;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import woojooin.planitbatch.batch.processor.IsaTaxSavingProcessor;
 import woojooin.planitbatch.batch.reader.IsaTaxSavingReader;

--- a/src/main/java/woojooin/planitbatch/batch/processor/IsaTaxSavingProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/IsaTaxSavingProcessor.java
@@ -17,8 +17,6 @@ import woojooin.planitbatch.global.util.IsaTaxCalculator;
 public class IsaTaxSavingProcessor implements ItemProcessor<UserProductQuarterData, IsaTaxSavingHistoryVo> {
 	@Override
 	public IsaTaxSavingHistoryVo process(UserProductQuarterData item) throws Exception {
-		log.info("processor!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-		log.info("data!!!!!!!!!!!!!!!!!: {}", item);
 		Long memberId = item.getMemberId();
 		String quarter = item.getQuarter();
 		// "general" 타입 고정, 필요시 변경 가능

--- a/src/main/java/woojooin/planitbatch/batch/processor/IsaTaxSavingProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/IsaTaxSavingProcessor.java
@@ -16,7 +16,6 @@ import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
-@EnableBatchProcessing
 public class IsaTaxSavingProcessor implements ItemProcessor<UserProductQuarterData, IsaTaxSavingHistoryVo> {
 
 	private final IsaTaxSavingMapper mapper;
@@ -36,7 +35,7 @@ public class IsaTaxSavingProcessor implements ItemProcessor<UserProductQuarterDa
 
 		IsaTaxSavingHistoryVo history = new IsaTaxSavingHistoryVo();
 		history.setMemberId(memberId);
-		history.setQuarter(DateUtils.getCurrentQuarter());
+		history.setQuarter(item.getQuarter());
 		history.setSavingAmount(currentSaving);
 		history.setAccumulatedSaving(newAccumulated);
 		history.setCreatedAt(LocalDateTime.now());

--- a/src/main/java/woojooin/planitbatch/batch/processor/IsaTaxSavingProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/IsaTaxSavingProcessor.java
@@ -1,0 +1,46 @@
+package woojooin.planitbatch.batch.processor;
+
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import woojooin.planitbatch.domain.dto.UserProductQuarterData;
+import woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper;
+import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
+import woojooin.planitbatch.global.util.DateUtils;
+import woojooin.planitbatch.global.util.IsaTaxCalculator;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+@EnableBatchProcessing
+public class IsaTaxSavingProcessor implements ItemProcessor<UserProductQuarterData, IsaTaxSavingHistoryVo> {
+
+	private final IsaTaxSavingMapper mapper;
+
+	@Override
+	public IsaTaxSavingHistoryVo process(UserProductQuarterData item) throws Exception {
+		BigDecimal totalProfit = item.getTotalProfit();
+		Long memberId = item.getMemberId();
+
+		IsaTaxCalculator.IsaTaxResult result = IsaTaxCalculator.calculateTaxSaving(totalProfit, "general");
+
+		BigDecimal lastAccumulated = mapper.selectLatestAccumulatedSaving(memberId);
+		if (lastAccumulated == null) lastAccumulated = BigDecimal.ZERO;
+
+		BigDecimal currentSaving = result.getTotalTaxSaved();
+		BigDecimal newAccumulated = lastAccumulated.add(currentSaving);
+
+		IsaTaxSavingHistoryVo history = new IsaTaxSavingHistoryVo();
+		history.setMemberId(memberId);
+		history.setQuarter(DateUtils.getCurrentQuarter());
+		history.setSavingAmount(currentSaving);
+		history.setAccumulatedSaving(newAccumulated);
+		history.setCreatedAt(LocalDateTime.now());
+
+		return history;
+	}
+}

--- a/src/main/java/woojooin/planitbatch/batch/processor/IsaTaxSavingProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/IsaTaxSavingProcessor.java
@@ -1,45 +1,33 @@
 package woojooin.planitbatch.batch.processor;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import java.math.BigDecimal;
+
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import woojooin.planitbatch.domain.dto.UserProductQuarterData;
-import woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper;
 import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
-import woojooin.planitbatch.global.util.DateUtils;
 import woojooin.planitbatch.global.util.IsaTaxCalculator;
-
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class IsaTaxSavingProcessor implements ItemProcessor<UserProductQuarterData, IsaTaxSavingHistoryVo> {
-
-	private final IsaTaxSavingMapper mapper;
-
 	@Override
 	public IsaTaxSavingHistoryVo process(UserProductQuarterData item) throws Exception {
-		BigDecimal totalProfit = item.getTotalProfit();
+		log.info("processor!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+		log.info("data!!!!!!!!!!!!!!!!!: {}", item);
 		Long memberId = item.getMemberId();
+		String quarter = item.getQuarter();
+		// "general" 타입 고정, 필요시 변경 가능
+		String userType = "general";
 
-		IsaTaxCalculator.IsaTaxResult result = IsaTaxCalculator.calculateTaxSaving(totalProfit, "general");
+		if (item.getTotalProfit() == null) {
+			item.setTotalProfit(BigDecimal.ZERO);
+		}
 
-		BigDecimal lastAccumulated = mapper.selectLatestAccumulatedSaving(memberId);
-		if (lastAccumulated == null) lastAccumulated = BigDecimal.ZERO;
-
-		BigDecimal currentSaving = result.getTotalTaxSaved();
-		BigDecimal newAccumulated = lastAccumulated.add(currentSaving);
-
-		IsaTaxSavingHistoryVo history = new IsaTaxSavingHistoryVo();
-		history.setMemberId(memberId);
-		history.setQuarter(item.getQuarter());
-		history.setSavingAmount(currentSaving);
-		history.setAccumulatedSaving(newAccumulated);
-		history.setCreatedAt(LocalDateTime.now());
-
-		return history;
+		return IsaTaxCalculator.calculateIsaTaxSavingHistoryVo(memberId, quarter, item.getTotalProfit(), userType);
 	}
 }

--- a/src/main/java/woojooin/planitbatch/batch/reader/IsaTaxSavingReader.java
+++ b/src/main/java/woojooin/planitbatch/batch/reader/IsaTaxSavingReader.java
@@ -27,7 +27,6 @@ public class IsaTaxSavingReader {
 		reader.setSqlSessionFactory(sqlSessionFactory);
 		reader.setQueryId("woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper.selectIsaProductProfitByMember");
 		reader.setPageSize(100);
-		reader.setParameterValues(new HashMap<>()); // 파라미터 필요 없을 경우 빈 map
 		return reader;
 	}
 }

--- a/src/main/java/woojooin/planitbatch/batch/reader/IsaTaxSavingReader.java
+++ b/src/main/java/woojooin/planitbatch/batch/reader/IsaTaxSavingReader.java
@@ -1,15 +1,10 @@
 package woojooin.planitbatch.batch.reader;
 
-import java.util.HashMap;
-
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.batch.MyBatisPagingItemReader;
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.StepScope;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +20,6 @@ public class IsaTaxSavingReader {
 	@Bean(name = "isaTaxReader")
 	@StepScope
 	public MyBatisPagingItemReader<UserProductQuarterData> isaTaxReader() {
-		log.info("reader!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 
 		MyBatisPagingItemReader<UserProductQuarterData> reader = new MyBatisPagingItemReader<>();
 		reader.setSqlSessionFactory(sqlSessionFactory);

--- a/src/main/java/woojooin/planitbatch/batch/reader/IsaTaxSavingReader.java
+++ b/src/main/java/woojooin/planitbatch/batch/reader/IsaTaxSavingReader.java
@@ -12,10 +12,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import woojooin.planitbatch.domain.dto.UserProductQuarterData;
 
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 public class IsaTaxSavingReader {
 
 	private final SqlSessionFactory sqlSessionFactory;
@@ -23,6 +25,8 @@ public class IsaTaxSavingReader {
 	@Bean(name = "isaTaxReader")
 	@StepScope
 	public MyBatisPagingItemReader<UserProductQuarterData> isaTaxReader() {
+		log.info("reader!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+
 		MyBatisPagingItemReader<UserProductQuarterData> reader = new MyBatisPagingItemReader<>();
 		reader.setSqlSessionFactory(sqlSessionFactory);
 		reader.setQueryId("woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper.selectIsaProductProfitByMember");

--- a/src/main/java/woojooin/planitbatch/batch/reader/IsaTaxSavingReader.java
+++ b/src/main/java/woojooin/planitbatch/batch/reader/IsaTaxSavingReader.java
@@ -1,0 +1,33 @@
+package woojooin.planitbatch.batch.reader;
+
+import java.util.HashMap;
+
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import woojooin.planitbatch.domain.dto.UserProductQuarterData;
+
+@Configuration
+@RequiredArgsConstructor
+public class IsaTaxSavingReader {
+
+	private final SqlSessionFactory sqlSessionFactory;
+
+	@Bean(name = "isaTaxReader")
+	@StepScope
+	public MyBatisPagingItemReader<UserProductQuarterData> isaTaxReader() {
+		MyBatisPagingItemReader<UserProductQuarterData> reader = new MyBatisPagingItemReader<>();
+		reader.setSqlSessionFactory(sqlSessionFactory);
+		reader.setQueryId("woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper.selectIsaProductProfitByMember");
+		reader.setPageSize(100);
+		reader.setParameterValues(new HashMap<>()); // 파라미터 필요 없을 경우 빈 map
+		return reader;
+	}
+}

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/BatchScheduler.java
@@ -1,54 +1,47 @@
 package woojooin.planitbatch.batch.scheduler;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.*;
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.explore.JobExplorer;
 import org.springframework.batch.core.launch.JobLauncher;
-import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
-@EnableBatchProcessing
-@EnableScheduling
-@Slf4j
 public class BatchScheduler {
 
 	private final JobLauncher jobLauncher;
 	private final JobExplorer jobExplorer;
 	private final Job isaTaxSavingJob;
 
-	@Scheduled(cron = "0 * * * * ?")  // 매 분 실행 (테스트용)
-	public void runIsaTaxSavingJob() throws Exception {
-		log.info("🔄 배치 job 실행 시도");
-
+	@Scheduled(cron = "0 31 10 * * *")  // 매일 2시 20분에 실행
+	public void runIsaTaxSavingJob() {
 		String jobName = isaTaxSavingJob.getName();
 
-		// 1. 최근 실행된 JobInstance 가져오기
-		long minIntervalMillis = 5 * 60 * 1000; // 5분
-		for (JobInstance instance : jobExplorer.getJobInstances(jobName, 0, 10)) {
-			for (JobExecution execution : jobExplorer.getJobExecutions(instance)) {
-				if (execution.isRunning()) {
-					log.warn("⚠️ Job '{}' si still running!!!!!!!!!, jump!!!!!!.", jobName);
-					return;
-				}
-				if (execution.getEndTime() != null) {
-					long elapsed = System.currentTimeMillis() - execution.getEndTime().getTime();
-					if (elapsed < minIntervalMillis) {
-						log.warn("⚠️ Job '{}' recently ended!!!!!!!!!! run{}s after!!!!!!!.", jobName, minIntervalMillis/1000);
-						return;
-					}
-				}
+		JobParameters jobParameters = new JobParametersBuilder()
+			.addLong("timestamp", System.currentTimeMillis()) // 매 실행마다 달라지는 값
+			.toJobParameters();
+
+		try {
+			// 현재 실행 중인 동일 Job이 있는지 확인 (jobName 기준)
+			if (!jobExplorer.findRunningJobExecutions(jobName).isEmpty()) {
+				log.warn("[스케줄러] Job '{}'이(가) 이미 실행 중입니다. 실행을 건너뜁니다.", jobName);
+				return;
 			}
+
+			log.info("[스케줄러] Job '{}' 실행을 시작합니다.", jobName);
+			JobExecution jobExecution = jobLauncher.run(isaTaxSavingJob, jobParameters);
+			log.info("[스케줄러] Job '{}' 실행 상태: {}", jobName, jobExecution.getStatus());
+
+		} catch (Exception e) {
+			log.error("[스케줄러] Job '{}' 실행 중 예외가 발생했습니다.", jobName, e);
 		}
-
-
-		// 2. 실행
-		jobLauncher.run(isaTaxSavingJob, new JobParametersBuilder()
-			.addLong("time", System.currentTimeMillis()) // 항상 다른 파라미터로 실행
-			.toJobParameters());
 	}
 }

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/BatchScheduler.java
@@ -28,14 +28,23 @@ public class BatchScheduler {
 		String jobName = isaTaxSavingJob.getName();
 
 		// 1. 최근 실행된 JobInstance 가져오기
+		long minIntervalMillis = 5 * 60 * 1000; // 5분
 		for (JobInstance instance : jobExplorer.getJobInstances(jobName, 0, 10)) {
 			for (JobExecution execution : jobExplorer.getJobExecutions(instance)) {
 				if (execution.isRunning()) {
-					log.warn("⚠️ Job '{}' 이(가) 아직 실행 중이므로, 새 실행을 건너뜁니다.", jobName);
+					log.warn("⚠️ Job '{}' si still running!!!!!!!!!, jump!!!!!!.", jobName);
 					return;
+				}
+				if (execution.getEndTime() != null) {
+					long elapsed = System.currentTimeMillis() - execution.getEndTime().getTime();
+					if (elapsed < minIntervalMillis) {
+						log.warn("⚠️ Job '{}' recently ended!!!!!!!!!! run{}s after!!!!!!!.", jobName, minIntervalMillis/1000);
+						return;
+					}
 				}
 			}
 		}
+
 
 		// 2. 실행
 		jobLauncher.run(isaTaxSavingJob, new JobParametersBuilder()

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/BatchScheduler.java
@@ -1,0 +1,45 @@
+package woojooin.planitbatch.batch.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@EnableBatchProcessing
+@EnableScheduling
+@Slf4j
+public class BatchScheduler {
+
+	private final JobLauncher jobLauncher;
+	private final JobExplorer jobExplorer;
+	private final Job isaTaxSavingJob;
+
+	@Scheduled(cron = "0 * * * * ?")  // 매 분 실행 (테스트용)
+	public void runIsaTaxSavingJob() throws Exception {
+		log.info("🔄 배치 job 실행 시도");
+
+		String jobName = isaTaxSavingJob.getName();
+
+		// 1. 최근 실행된 JobInstance 가져오기
+		for (JobInstance instance : jobExplorer.getJobInstances(jobName, 0, 10)) {
+			for (JobExecution execution : jobExplorer.getJobExecutions(instance)) {
+				if (execution.isRunning()) {
+					log.warn("⚠️ Job '{}' 이(가) 아직 실행 중이므로, 새 실행을 건너뜁니다.", jobName);
+					return;
+				}
+			}
+		}
+
+		// 2. 실행
+		jobLauncher.run(isaTaxSavingJob, new JobParametersBuilder()
+			.addLong("time", System.currentTimeMillis()) // 항상 다른 파라미터로 실행
+			.toJobParameters());
+	}
+}

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/BatchScheduler.java
@@ -21,7 +21,7 @@ public class BatchScheduler {
 	private final JobExplorer jobExplorer;
 	private final Job isaTaxSavingJob;
 
-	@Scheduled(cron = "0 31 10 * * *")  // 매일 2시 20분에 실행
+	@Scheduled(cron = "0 13 11 * * *")  // 매일 2시 20분에 실행
 	public void runIsaTaxSavingJob() {
 		String jobName = isaTaxSavingJob.getName();
 

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/IsaTaxSavingJobBatchScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/IsaTaxSavingJobBatchScheduler.java
@@ -15,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class BatchScheduler {
+public class IsaTaxSavingJobBatchScheduler {
 
 	private final JobLauncher jobLauncher;
 	private final JobExplorer jobExplorer;

--- a/src/main/java/woojooin/planitbatch/batch/writer/IsaTaxSavingWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/IsaTaxSavingWriter.java
@@ -1,0 +1,26 @@
+package woojooin.planitbatch.batch.writer;
+
+import java.util.List;
+
+import org.springframework.batch.item.ItemWriter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper;
+import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
+
+@Component
+@RequiredArgsConstructor
+public class IsaTaxSavingWriter implements ItemWriter<IsaTaxSavingHistoryVo> {
+
+	private final IsaTaxSavingMapper mapper;
+
+	@Override
+	public void write(List<? extends IsaTaxSavingHistoryVo> items) throws Exception {
+		for (IsaTaxSavingHistoryVo history : items) {
+			mapper.insertTaxSavingHistory(history);
+		}
+	}
+}

--- a/src/main/java/woojooin/planitbatch/batch/writer/IsaTaxSavingWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/IsaTaxSavingWriter.java
@@ -20,7 +20,20 @@ public class IsaTaxSavingWriter implements ItemWriter<IsaTaxSavingHistoryVo> {
 	@Override
 	public void write(List<? extends IsaTaxSavingHistoryVo> items) throws Exception {
 		for (IsaTaxSavingHistoryVo history : items) {
-			mapper.insertTaxSavingHistory(history);
+			try {
+				mapper.insertTaxSavingHistory(history);
+			} catch (Exception e) {
+				// 개별 실패 로깅
+				System.err.println("[Insert 실패] memberId: " + history.getMemberId() + ", quarter: " + history.getQuarter());
+				e.printStackTrace();
+				// 실패 아이템 별도 처리 가능 (예: 실패 리스트에 저장, 알림 등)
+			}
 		}
 	}
+
+	//MyBatis 다중 Insert
+	// @Override
+	// public void write(List<? extends IsaTaxSavingHistoryVo> items) throws Exception {
+	// 	mapper.insertTaxSavingHistoryBatch((List<IsaTaxSavingHistoryVo>) items);
+	// }
 }

--- a/src/main/java/woojooin/planitbatch/batch/writer/IsaTaxSavingWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/IsaTaxSavingWriter.java
@@ -6,7 +6,6 @@ import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -19,24 +18,18 @@ import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
 @Slf4j
 public class IsaTaxSavingWriter implements ItemWriter<IsaTaxSavingHistoryVo> {
 
-	private final IsaTaxSavingMapper mapper;
-
-	@Autowired
-	private SqlSessionFactory sqlSessionFactory;
+	private final SqlSessionFactory sqlSessionFactory;
 
 	@Override
 	public void write(List<? extends IsaTaxSavingHistoryVo> items) throws Exception {
-		log.info("writer!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-		log.info("data!!!!!!!!!!!!!!!!!: {}", items);
 
 		try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH, false)) {
 			IsaTaxSavingMapper mapper = sqlSession.getMapper(IsaTaxSavingMapper.class);
 			for (IsaTaxSavingHistoryVo item : items) {
 				mapper.upsertIsaTaxSavingHistory(item);
 			}
-			sqlSession.commit(); // 꼭 커밋해야 함!
+			sqlSession.commit();
 		} catch (Exception e) {
-			System.err.println("[Insert/Update 배치 실패] 아이템 개수: " + items.size());
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/woojooin/planitbatch/batch/writer/IsaTaxSavingWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/IsaTaxSavingWriter.java
@@ -2,38 +2,44 @@ package woojooin.planitbatch.batch.writer;
 
 import java.util.List;
 
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.batch.item.ItemWriter;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper;
 import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class IsaTaxSavingWriter implements ItemWriter<IsaTaxSavingHistoryVo> {
 
 	private final IsaTaxSavingMapper mapper;
 
+	@Autowired
+	private SqlSessionFactory sqlSessionFactory;
+
 	@Override
 	public void write(List<? extends IsaTaxSavingHistoryVo> items) throws Exception {
-		for (IsaTaxSavingHistoryVo history : items) {
-			try {
-				mapper.insertTaxSavingHistory(history);
-			} catch (Exception e) {
-				// 개별 실패 로깅
-				System.err.println("[Insert 실패] memberId: " + history.getMemberId() + ", quarter: " + history.getQuarter());
-				e.printStackTrace();
-				// 실패 아이템 별도 처리 가능 (예: 실패 리스트에 저장, 알림 등)
+		log.info("writer!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+		log.info("data!!!!!!!!!!!!!!!!!: {}", items);
+
+		try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH, false)) {
+			IsaTaxSavingMapper mapper = sqlSession.getMapper(IsaTaxSavingMapper.class);
+			for (IsaTaxSavingHistoryVo item : items) {
+				mapper.upsertIsaTaxSavingHistory(item);
 			}
+			sqlSession.commit(); // 꼭 커밋해야 함!
+		} catch (Exception e) {
+			System.err.println("[Insert/Update 배치 실패] 아이템 개수: " + items.size());
+			e.printStackTrace();
 		}
 	}
 
-	//MyBatis 다중 Insert
-	// @Override
-	// public void write(List<? extends IsaTaxSavingHistoryVo> items) throws Exception {
-	// 	mapper.insertTaxSavingHistoryBatch((List<IsaTaxSavingHistoryVo>) items);
-	// }
+
 }

--- a/src/main/java/woojooin/planitbatch/domain/dto/UserProductQuarterData.java
+++ b/src/main/java/woojooin/planitbatch/domain/dto/UserProductQuarterData.java
@@ -1,0 +1,12 @@
+package woojooin.planitbatch.domain.dto;
+
+
+import java.math.BigDecimal;
+import lombok.Data;
+
+@Data
+public class UserProductQuarterData {
+	private Long memberId;
+	private String quarter;
+	private BigDecimal totalProfit;
+}

--- a/src/main/java/woojooin/planitbatch/domain/mapper/IsaTaxSavingMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/IsaTaxSavingMapper.java
@@ -11,9 +11,10 @@ import org.apache.ibatis.annotations.Param;
 import woojooin.planitbatch.domain.dto.UserProductQuarterData;
 import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
 
-@Mapper
 public interface IsaTaxSavingMapper {
 	List<UserProductQuarterData> selectIsaProductProfitByMember();
+
+	void insertTaxSavingHistoryBatch(@Param("list") List<IsaTaxSavingHistoryVo> histories);
 
 	void insertTaxSavingHistory(IsaTaxSavingHistoryVo history);
 

--- a/src/main/java/woojooin/planitbatch/domain/mapper/IsaTaxSavingMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/IsaTaxSavingMapper.java
@@ -14,9 +14,8 @@ import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
 public interface IsaTaxSavingMapper {
 	List<UserProductQuarterData> selectIsaProductProfitByMember();
 
-	void insertTaxSavingHistoryBatch(@Param("list") List<IsaTaxSavingHistoryVo> histories);
+	int upsertIsaTaxSavingHistory(IsaTaxSavingHistoryVo vo);
 
-	void insertTaxSavingHistory(IsaTaxSavingHistoryVo history);
+	int upsertIsaTaxSavingHistoryBatch(@Param("items") List<IsaTaxSavingHistoryVo> items);
 
-	BigDecimal selectLatestAccumulatedSaving(@Param("memberId") Long memberId);
 }

--- a/src/main/java/woojooin/planitbatch/domain/mapper/IsaTaxSavingMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/IsaTaxSavingMapper.java
@@ -1,12 +1,7 @@
 package woojooin.planitbatch.domain.mapper;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.List;
-import java.util.Map;
 
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
 
 import woojooin.planitbatch.domain.dto.UserProductQuarterData;
 import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
@@ -15,7 +10,5 @@ public interface IsaTaxSavingMapper {
 	List<UserProductQuarterData> selectIsaProductProfitByMember();
 
 	int upsertIsaTaxSavingHistory(IsaTaxSavingHistoryVo vo);
-
-	int upsertIsaTaxSavingHistoryBatch(@Param("items") List<IsaTaxSavingHistoryVo> items);
 
 }

--- a/src/main/java/woojooin/planitbatch/domain/mapper/IsaTaxSavingMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/IsaTaxSavingMapper.java
@@ -1,0 +1,21 @@
+package woojooin.planitbatch.domain.mapper;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import woojooin.planitbatch.domain.dto.UserProductQuarterData;
+import woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo;
+
+@Mapper
+public interface IsaTaxSavingMapper {
+	List<UserProductQuarterData> selectIsaProductProfitByMember();
+
+	void insertTaxSavingHistory(IsaTaxSavingHistoryVo history);
+
+	BigDecimal selectLatestAccumulatedSaving(@Param("memberId") Long memberId);
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/IsaTaxSavingHistoryVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/IsaTaxSavingHistoryVo.java
@@ -1,0 +1,17 @@
+package woojooin.planitbatch.domain.vo;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class IsaTaxSavingHistoryVo {
+	private Long memberId;
+	private String quarter;
+	private BigDecimal savingAmount;
+	private BigDecimal accumulatedSaving;
+	private LocalDateTime createdAt;
+}
+

--- a/src/main/java/woojooin/planitbatch/domain/vo/IsaTaxSavingHistoryVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/IsaTaxSavingHistoryVo.java
@@ -1,6 +1,7 @@
 package woojooin.planitbatch.domain.vo;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import lombok.Builder;
@@ -8,10 +9,12 @@ import lombok.Data;
 
 @Data
 public class IsaTaxSavingHistoryVo {
+
 	private Long memberId;
-	private String quarter;
-	private BigDecimal savingAmount;
-	private BigDecimal accumulatedSaving;
-	private LocalDateTime createdAt;
+	private String quarter; // 예: "2024-Q1"
+	private Long isaProfit; // ISA 수익
+	private Long generalTax; // 일반계좌였다면 냈을 세금 = isaProfit * 0.154
+	private Long taxSaved; // 절세 금액 = generalTax - 0 = generalTax
+
 }
 

--- a/src/main/java/woojooin/planitbatch/global/config/DatabaseConfig.java
+++ b/src/main/java/woojooin/planitbatch/global/config/DatabaseConfig.java
@@ -19,7 +19,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -30,122 +29,120 @@ import com.zaxxer.hikari.HikariDataSource;
 @Configuration
 @EnableBatchProcessing
 @PropertySource("classpath:application.properties")
-@MapperScan(basePackages = {"woojooin.planitbatch.domain.mapper", "woojooin.planitbatch.domain.product.mapper",
-	"woojooin.planitbatch.domain.rebalance.mapper"})
+@MapperScan("woojooin.planitbatch.domain.mapper")
 public class DatabaseConfig implements BatchConfigurer {
 
-	@Value("${jdbc.driver}")
-	private String driverClassName;
+    @Value("${jdbc.driver}")
+    private String driverClassName;
 
-	@Value("${jdbc.url}")
-	private String url;
+    @Value("${jdbc.url}")
+    private String url;
 
-	@Value("${jdbc.username}")
-	private String username;
+    @Value("${jdbc.username}")
+    private String username;
 
-	@Value("${jdbc.password}")
-	private String password;
+    @Value("${jdbc.password}")
+    private String password;
 
-	@Value("${batch.jdbc.driver}")
-	private String batchDriverClassName;
+    @Value("${batch.jdbc.driver}")
+    private String batchDriverClassName;
 
-	@Value("${batch.jdbc.url}")
-	private String batchUrl;
+    @Value("${batch.jdbc.url}")
+    private String batchUrl;
 
-	@Value("${batch.jdbc.username}")
-	private String batchUsername;
+    @Value("${batch.jdbc.username}")
+    private String batchUsername;
 
-	@Value("${batch.jdbc.password}")
-	private String batchPassword;
+    @Value("${batch.jdbc.password}")
+    private String batchPassword;
 
-	@Bean
-	@Primary
-	public DataSource dataSource() {
-		HikariConfig config = new HikariConfig();
-		config.setDriverClassName(driverClassName);
-		config.setJdbcUrl(url);
-		config.setUsername(username);
-		config.setPassword(password);
-		config.setMaximumPoolSize(10);
+    @Bean
+    @Primary
+    public DataSource dataSource() {
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName(driverClassName);
+        config.setJdbcUrl(url);
+        config.setUsername(username);
+        config.setPassword(password);
+        config.setMaximumPoolSize(10);
 
-		config.setConnectionTimeout(20000);
-		config.setIdleTimeout(300000);
-		config.setMaxLifetime(1200000);
-		config.setLeakDetectionThreshold(15000);
+        config.setConnectionTimeout(20000);
+        config.setIdleTimeout(300000);
+        config.setMaxLifetime(1200000);
+        config.setLeakDetectionThreshold(15000);
 
-		return new HikariDataSource(config);
-	}
+        return new HikariDataSource(config);
+    }
 
-	@Bean("batchDataSource")
-	public DataSource batchDataSource() {
-		HikariConfig config = new HikariConfig();
-		config.setDriverClassName(batchDriverClassName);
-		config.setJdbcUrl(batchUrl);
-		config.setUsername(batchUsername);
-		config.setPassword(batchPassword);
-		config.setMaximumPoolSize(5);
+    @Bean("batchDataSource")
+    public DataSource batchDataSource() {
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName(batchDriverClassName);
+        config.setJdbcUrl(batchUrl);
+        config.setUsername(batchUsername);
+        config.setPassword(batchPassword);
+        config.setMaximumPoolSize(5);
 
-		config.setConnectionTimeout(20000);
-		config.setIdleTimeout(300000);
-		config.setMaxLifetime(1200000);
-		config.setLeakDetectionThreshold(15000);
+        config.setConnectionTimeout(20000);
+        config.setIdleTimeout(300000);
+        config.setMaxLifetime(1200000);
+        config.setLeakDetectionThreshold(15000);
 
-		return new HikariDataSource(config);
-	}
+        return new HikariDataSource(config);
+    }
 
-	@Bean
-	public SqlSessionFactory sqlSessionFactory() throws Exception {
-		SqlSessionFactoryBean sessionFactory = new SqlSessionFactoryBean();
+    @Bean
+    public SqlSessionFactory sqlSessionFactory() throws Exception {
+        SqlSessionFactoryBean sessionFactory = new SqlSessionFactoryBean();
 
-		sessionFactory.setDataSource(dataSource());
+        sessionFactory.setDataSource(dataSource());
 
-		sessionFactory.setConfigLocation(new ClassPathResource("mybatis-config.xml"));
-		sessionFactory.setMapperLocations(
-			new PathMatchingResourcePatternResolver()
-				.getResources("classpath:mapper/*.xml")
-		);
+        sessionFactory.setMapperLocations(
+            new PathMatchingResourcePatternResolver()
+                .getResources("classpath:mapper/*.xml")
+        );
 
-		return sessionFactory.getObject();
-	}
+        return sessionFactory.getObject();
+    }
 
-	@Bean
-	public SqlSessionTemplate sqlSessionTemplate() throws Exception {
-		return new SqlSessionTemplate(sqlSessionFactory());
-	}
+    @Bean
+    public SqlSessionTemplate sqlSessionTemplate() throws Exception {
+        return new SqlSessionTemplate(sqlSessionFactory());
+    }
 
-	@Bean("batchTransactionManager")
-	public PlatformTransactionManager batchTransactionManager() {
-		return new DataSourceTransactionManager(batchDataSource());
-	}
+    @Bean("batchTransactionManager")
+    public PlatformTransactionManager batchTransactionManager() {
+        return new DataSourceTransactionManager(batchDataSource());
+    }
 
-	@Override
-	public JobRepository getJobRepository() throws Exception {
-		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
-		factory.setDataSource(batchDataSource());
-		factory.setTransactionManager(batchTransactionManager());
-		factory.afterPropertiesSet();
-		return factory.getObject();
-	}
+    @Override
+    public JobRepository getJobRepository() throws Exception {
+        JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
+        factory.setDataSource(batchDataSource());
+        factory.setTransactionManager(batchTransactionManager());
+        factory.afterPropertiesSet();
+        return factory.getObject();
+    }
 
-	@Override
-	public PlatformTransactionManager getTransactionManager() throws Exception {
-		return batchTransactionManager();
-	}
+    @Override
+    public PlatformTransactionManager getTransactionManager() throws Exception {
+        return batchTransactionManager();
+    }
 
-	@Override
-	public JobLauncher getJobLauncher() throws Exception {
-		SimpleJobLauncher jobLauncher = new SimpleJobLauncher();
-		jobLauncher.setJobRepository(getJobRepository());
-		jobLauncher.afterPropertiesSet();
-		return jobLauncher;
-	}
+    @Override
+    public JobLauncher getJobLauncher() throws Exception {
+        SimpleJobLauncher jobLauncher = new SimpleJobLauncher();
+        jobLauncher.setJobRepository(getJobRepository());
+        jobLauncher.afterPropertiesSet();
+        return jobLauncher;
+    }
 
-	@Override
-	public JobExplorer getJobExplorer() throws Exception {
-		JobExplorerFactoryBean jobExplorerFactoryBean = new JobExplorerFactoryBean();
-		jobExplorerFactoryBean.setDataSource(batchDataSource());
-		jobExplorerFactoryBean.afterPropertiesSet();
-		return jobExplorerFactoryBean.getObject();
-	}
+    @Override
+    public JobExplorer getJobExplorer() throws Exception {
+        JobExplorerFactoryBean jobExplorerFactoryBean = new JobExplorerFactoryBean();
+        jobExplorerFactoryBean.setDataSource(batchDataSource());
+        jobExplorerFactoryBean.afterPropertiesSet();
+        return jobExplorerFactoryBean.getObject();
+    }
 
 }

--- a/src/main/java/woojooin/planitbatch/global/util/DateUtils.java
+++ b/src/main/java/woojooin/planitbatch/global/util/DateUtils.java
@@ -1,0 +1,21 @@
+package woojooin.planitbatch.global.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+
+public class DateUtils {
+
+	//분기 계산
+	public static String getCurrentQuarter() {
+		LocalDate now = LocalDate.now();
+		int quarter = (now.getMonthValue() - 1) / 3 + 1;
+		return now.getYear() + "-Q" + quarter;
+	}
+
+	public static String getQuarter(LocalDate date) {
+		int quarter = (date.getMonthValue() - 1) / 3 + 1;
+		return date.getYear() + "-Q" + quarter;
+	}
+
+}

--- a/src/main/java/woojooin/planitbatch/global/util/IsaTaxCalculator.java
+++ b/src/main/java/woojooin/planitbatch/global/util/IsaTaxCalculator.java
@@ -1,0 +1,95 @@
+package woojooin.planitbatch.global.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class IsaTaxCalculator {
+
+	/**
+	 * ISA 계좌의 절세 효과를 계산한다.
+	 *
+	 * @param totalProfit ISA 계좌 전체 수익
+	 * @param userType "general" (일반형) 또는 "preferential" (서민형/청년형)
+	 * @return IsaTaxResult (절세 이익 + 누적 절세)
+	 */
+	public static IsaTaxResult calculateTaxSaving(BigDecimal totalProfit, String userType) {
+		BigDecimal isaLimit = userType.equalsIgnoreCase("preferential")
+			? new BigDecimal("4000000")
+			: new BigDecimal("2000000");
+
+		BigDecimal generalTaxRate = new BigDecimal("0.154"); // 일반 계좌 세율: 15.4%
+		BigDecimal isaOverLimitTaxRate = new BigDecimal("0.099"); // ISA 초과분 분리과세: 9.9%
+
+		// 일반 계좌 기준 세금
+		BigDecimal taxIfGeneralAccount = totalProfit.multiply(generalTaxRate);
+
+		BigDecimal taxFreeAmount; // ISA 한도 내 금액
+		BigDecimal taxableExcessAmount = BigDecimal.ZERO;
+		BigDecimal actualIsaTax = BigDecimal.ZERO;
+
+		if (totalProfit.compareTo(isaLimit) <= 0) {
+			taxFreeAmount = totalProfit;
+		} else {
+			taxFreeAmount = isaLimit;
+			taxableExcessAmount = totalProfit.subtract(isaLimit);
+			actualIsaTax = taxableExcessAmount.multiply(isaOverLimitTaxRate);
+		}
+
+		// 누적 절세 금액 = 일반 계좌 세금 - ISA 세금
+		BigDecimal totalTaxSaved = taxIfGeneralAccount.subtract(actualIsaTax);
+
+		return new IsaTaxResult(
+			taxFreeAmount.setScale(2, RoundingMode.DOWN),
+			taxableExcessAmount.setScale(2, RoundingMode.DOWN),
+			actualIsaTax.setScale(2, RoundingMode.DOWN),
+			totalTaxSaved.setScale(2, RoundingMode.DOWN)
+		);
+	}
+
+	public static class IsaTaxResult {
+		private BigDecimal taxFreeAmount;           // 한도 내 비과세 금액
+		private BigDecimal taxableExcessAmount;     // 한도 초과 금액
+		private BigDecimal actualIsaTax;            // ISA에서 실제 낸 세금 (9.9%)
+		private BigDecimal totalTaxSaved;           // 일반 계좌 대비 절세 금액
+
+		public IsaTaxResult(BigDecimal taxFreeAmount, BigDecimal taxableExcessAmount,
+			BigDecimal actualIsaTax, BigDecimal totalTaxSaved) {
+			this.taxFreeAmount = taxFreeAmount;
+			this.taxableExcessAmount = taxableExcessAmount;
+			this.actualIsaTax = actualIsaTax;
+			this.totalTaxSaved = totalTaxSaved;
+		}
+
+		public BigDecimal getTaxFreeAmount() {
+			return taxFreeAmount;
+		}
+
+		public BigDecimal getTaxableExcessAmount() {
+			return taxableExcessAmount;
+		}
+
+		public BigDecimal getActualIsaTax() {
+			return actualIsaTax;
+		}
+
+		public BigDecimal getTotalTaxSaved() {
+			return totalTaxSaved;
+		}
+
+		// ISA 세금을 뺀 실제 수익
+		public BigDecimal getActualProfitAmount(){
+			BigDecimal actualAmount = taxableExcessAmount.subtract(actualIsaTax);
+			return taxFreeAmount.add(actualAmount);
+		}
+
+		@Override
+		public String toString() {
+			return "IsaTaxResult{" +
+				"taxFreeAmount=" + taxFreeAmount +
+				", taxableExcessAmount=" + taxableExcessAmount +
+				", actualIsaTax=" + actualIsaTax +
+				", totalTaxSaved=" + totalTaxSaved +
+				'}';
+		}
+	}
+}

--- a/src/main/java/woojooin/planitbatch/global/util/IsaTaxCalculator.java
+++ b/src/main/java/woojooin/planitbatch/global/util/IsaTaxCalculator.java
@@ -44,8 +44,8 @@ public class IsaTaxCalculator {
 		IsaTaxSavingHistoryVo vo = new IsaTaxSavingHistoryVo();
 		vo.setMemberId(memberId);
 		vo.setQuarter(quarter);
-		vo.setIsaProfit(taxFreeAmount.setScale(0, RoundingMode.DOWN).longValue()); // 소수점 버림 후 Long 변환
-		vo.setGeneralTax(actualIsaTax.setScale(0, RoundingMode.DOWN).longValue());
+		vo.setIsaProfit(totalProfit.setScale(0, RoundingMode.DOWN).longValue()); // 소수점 버림 후 Long 변환
+		vo.setGeneralTax(taxIfGeneralAccount.setScale(0, RoundingMode.DOWN).longValue());
 		vo.setTaxSaved(totalTaxSaved.setScale(0, RoundingMode.DOWN).longValue());
 
 		return vo;

--- a/src/main/resources/mapper/IsaTaxSavingMapper.xml
+++ b/src/main/resources/mapper/IsaTaxSavingMapper.xml
@@ -32,19 +32,6 @@
                                 tax_saved   = VALUES(tax_saved)
     </insert>
 
-    <insert id="upsertIsaTaxSavingHistoryBatch" parameterType="java.util.List">
-        INSERT INTO isa_tax_saving_history (member_id, quarter, isa_profit, general_tax, tax_saved)
-        VALUES
-        <foreach collection="items" item="item" separator=",">
-            (#{item.memberId}, #{item.quarter}, #{item.isaProfit}, #{item.generalTax}, #{item.taxSaved})
-        </foreach>
-        ON DUPLICATE KEY UPDATE
-        isa_profit = VALUES(isa_profit),
-        general_tax = VALUES(general_tax),
-        tax_saved = VALUES(tax_saved)
-    </insert>
-
-
 </mapper>
 
 

--- a/src/main/resources/mapper/IsaTaxSavingMapper.xml
+++ b/src/main/resources/mapper/IsaTaxSavingMapper.xml
@@ -4,65 +4,46 @@
 <mapper namespace="woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper">
     <!-- ISA 계좌 상품 목록을 회원별로 그룹핑해서 조회 -->
     <select id="selectIsaProductProfitByMember"
-            parameterType="map"
             resultType="woojooin.planitbatch.domain.dto.UserProductQuarterData">
 
-        SELECT mp.member_id,
-               #{quarter}                                              AS quarter,
-               SUM(p.closing_price * mp.quantity - mp.purchase_amount) AS total_profit
-        FROM member_product mp
-                 JOIN
-             (SELECT p1.*
-              FROM product p1
-                       INNER JOIN (SELECT product_id, MAX(base_date) AS latest_date
-                                   FROM product
-                                   GROUP BY product_id) p2
-                                  ON p1.product_id = p2.product_id AND p1.base_date = p2.latest_date) p
-             ON mp.product_id = p.product_id
-        WHERE p.closing_price IS NOT NULL
-          AND mp.quantity IS NOT NULL
-          AND mp.purchase_amount IS NOT NULL
-        GROUP BY mp.member_id
+        SELECT member_id                   AS memberId,
+               CONCAT(year, '-Q', quarter) AS quarter,
+               total_profit                AS totalProfit
+        FROM (SELECT mp.member_id,
+                     YEAR(p.base_date)    AS year,
+                     QUARTER(p.base_date) AS quarter,
+                     SUM(
+                             COALESCE(p.closing_price, 0) * COALESCE(mp.quantity, 0)
+                                 - COALESCE(mp.purchase_amount, 0)
+                     )                    AS total_profit
+              FROM member_product mp
+                       JOIN product p ON mp.product_id = p.shorten_code
+              WHERE p.base_date IS NOT NULL
+              GROUP BY mp.member_id, YEAR(p.base_date), QUARTER(p.base_date)) sub
+
     </select>
 
 
-    <insert id="insertTaxSavingHistoryBatch" parameterType="list">
-        INSERT INTO isa_tax_saving_history (
-        member_id,
-        quarter,
-        saving_amount,
-        accumulated_saving,
-        created_at
-        )
+    <insert id="upsertIsaTaxSavingHistory" parameterType="woojooin.planitbatch.domain.vo.IsaTaxSavingHistoryVo">
+        INSERT INTO isa_tax_saving_history (member_id, quarter, isa_profit, general_tax, tax_saved)
+        VALUES (#{memberId}, #{quarter}, #{isaProfit}, #{generalTax}, #{taxSaved})
+        ON DUPLICATE KEY UPDATE isa_profit  = VALUES(isa_profit),
+                                general_tax = VALUES(general_tax),
+                                tax_saved   = VALUES(tax_saved)
+    </insert>
+
+    <insert id="upsertIsaTaxSavingHistoryBatch" parameterType="java.util.List">
+        INSERT INTO isa_tax_saving_history (member_id, quarter, isa_profit, general_tax, tax_saved)
         VALUES
-        <foreach collection="list" item="item" separator=",">
-            (#{item.memberId}, #{item.quarter}, #{item.savingAmount}, #{item.accumulatedSaving}, #{item.createdAt})
+        <foreach collection="items" item="item" separator=",">
+            (#{item.memberId}, #{item.quarter}, #{item.isaProfit}, #{item.generalTax}, #{item.taxSaved})
         </foreach>
+        ON DUPLICATE KEY UPDATE
+        isa_profit = VALUES(isa_profit),
+        general_tax = VALUES(general_tax),
+        tax_saved = VALUES(tax_saved)
     </insert>
 
-
-    <!-- 계산한 절세 금액을 기록 -->
-    <insert id="insertTaxSavingHistory">
-        INSERT INTO isa_tax_saving_history (member_id,
-                                            quarter,
-                                            saving_amount,
-                                            accumulated_saving,
-                                            created_at)
-        VALUES (#{memberId},
-                #{quarter},
-                #{savingAmount},
-                #{accumulatedSaving},
-                NOW())
-    </insert>
-
-    <!-- 가장 최신 누적 금액 조회 -->
-    <select id="selectLatestAccumulatedSaving" resultType="java.math.BigDecimal">
-        SELECT accumulated_saving
-        FROM isa_tax_saving_history
-        WHERE member_id = #{memberId}
-        ORDER BY quarter DESC
-        LIMIT 1
-    </select>
 
 </mapper>
 

--- a/src/main/resources/mapper/IsaTaxSavingMapper.xml
+++ b/src/main/resources/mapper/IsaTaxSavingMapper.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="woojooin.planitbatch.domain.mapper.IsaTaxSavingMapper">
+    <!-- ISA 계좌 상품 목록을 회원별로 그룹핑해서 조회 -->
+    <select id="selectIsaProductProfitByMember"
+            parameterType="map"
+            resultType="woojooin.planitbatch.domain.dto.UserProductQuarterData">
+
+        SELECT mp.member_id,
+               #{quarter}                                              AS quarter,
+               SUM(p.closing_price * mp.quantity - mp.purchase_amount) AS total_profit
+        FROM member_product mp
+                 JOIN
+             (SELECT p1.*
+              FROM product p1
+                       INNER JOIN (SELECT product_id, MAX(base_date) AS latest_date
+                                   FROM product
+                                   GROUP BY product_id) p2
+                                  ON p1.product_id = p2.product_id AND p1.base_date = p2.latest_date) p
+             ON mp.product_id = p.product_id
+        WHERE p.closing_price IS NOT NULL
+          AND mp.quantity IS NOT NULL
+          AND mp.purchase_amount IS NOT NULL
+        GROUP BY mp.member_id
+    </select>
+
+
+    <insert id="insertTaxSavingHistoryBatch" parameterType="list">
+        INSERT INTO isa_tax_saving_history (
+        member_id,
+        quarter,
+        saving_amount,
+        accumulated_saving,
+        created_at
+        )
+        VALUES
+        <foreach collection="list" item="item" separator=",">
+            (#{item.memberId}, #{item.quarter}, #{item.savingAmount}, #{item.accumulatedSaving}, #{item.createdAt})
+        </foreach>
+    </insert>
+
+
+    <!-- 계산한 절세 금액을 기록 -->
+    <insert id="insertTaxSavingHistory">
+        INSERT INTO isa_tax_saving_history (member_id,
+                                            quarter,
+                                            saving_amount,
+                                            accumulated_saving,
+                                            created_at)
+        VALUES (#{memberId},
+                #{quarter},
+                #{savingAmount},
+                #{accumulatedSaving},
+                NOW())
+    </insert>
+
+    <!-- 가장 최신 누적 금액 조회 -->
+    <select id="selectLatestAccumulatedSaving" resultType="java.math.BigDecimal">
+        SELECT accumulated_saving
+        FROM isa_tax_saving_history
+        WHERE member_id = #{memberId}
+        ORDER BY quarter DESC
+        LIMIT 1
+    </select>
+
+</mapper>
+
+


### PR DESCRIPTION
## 🔖 PR 유형
- [ ] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
SA 절세 계산 로직을 스프링 배치로 구현하고, 실행 중 발생한 ExecutorType 충돌 및 트랜잭션 관련 오류들을 해결하여 전체 배치 작업을 안정적으로 완성했습니다.


## 🔧 작업 내용
1. 배치 Job/Step 구성
- isaTaxSavingJob 생성
- isaTaxSavingStep 등록 (Chunk 기반: Reader → Processor → Writer)

2. Reader 구현
- 사용자별 ISA 상품 수익 조회 로직 작성
- selectIsaProductProfitByMember 쿼리에서 GROUP BY 오류 수정 (only_full_group_by 대응)

3. Processor 구현
- 일반 과세 계산 및 절세 금액 계산 로직 구현
- DateUtils.getCurrentQuarter() 로 현재 분기 계산

4. Writer 구현
- isa_tax_saving_history 테이블에 INSERT ... ON DUPLICATE KEY UPDATE 방식으로 적재
- 사용자별 + 분기별 복합 유니크 제약조건 (member_id + quarter) 적용 확인

5. Scheduler 설정
- @Scheduled 로 주기적 실행 처리
- JobLauncher에 SimpleAsyncTaskExecutor 설정해 중복 실행 방지 (JobInstanceAlreadyCompleteException 해결)

6. 주요 오류 해결 내역
- SqlSessionTemplate의 기본 ExecutorType.SIMPLE과 BATCH 혼용 충돌 해결
- MySQL only_full_group_by 모드에서 발생하는 GROUP BY 오류 수정
- 중복 Job 실행 방지를 위한 JobParameters 동적 생성 적용 (timestamp 포함)

## ✅ 체크리스트
- [ ] 배치 작업 정상 실행됨
- [ ] 로그로 각 사용자별 절세 결과 출력 확인
- [ ] DB isa_tax_saving_history 테이블에 정상 적재 확인 (중복 없이 갱신 처리)

## 📝 기타 참고 사항
- 중복 Job 실행 문제 여전히 존재

## 📎 관련 이슈
Close #11 
