### PR TITLE
[FEAT #18] 수익률 막대 그래프 배치

### DIFF
--- a/src/main/java/woojooin/planitbatch/batch/job/DailyReturnBatchJob.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/DailyReturnBatchJob.java
@@ -1,0 +1,68 @@
+package woojooin.planitbatch.batch.job;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+//import woojooin.planitbatch.batch.reader.DailyReturnReader;
+import woojooin.planitbatch.batch.writer.DailyReturnWriter;
+import woojooin.planitbatch.domain.mapper.DailyReturnMapper;
+import woojooin.planitbatch.domain.vo.DailyReturn;
+import org.springframework.beans.factory.annotation.Value;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableBatchProcessing
+@RequiredArgsConstructor
+@Configuration
+public class DailyReturnBatchJob {
+
+    private final JobBuilderFactory jobs;
+    private final StepBuilderFactory steps;
+//    private final DailyReturnReader dailyReturnReader;
+    private final DailyReturnWriter writer;
+    private final SqlSessionFactory sqlSessionFactory;
+
+
+    @Bean
+    @StepScope
+    public MyBatisPagingItemReader<DailyReturn> reader(
+            @Value("#{jobParameters['date']}") String dateStr) {
+        MyBatisPagingItemReader<DailyReturn> reader = new MyBatisPagingItemReader<>();
+
+        reader.setSqlSessionFactory(sqlSessionFactory);
+        reader.setQueryId("woojooin.planitbatch.domain.mapper.DailyReturnMapper.findAllForToday");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("date", LocalDate.parse(dateStr));
+        reader.setParameterValues(parameters);
+        reader.setPageSize(100);
+
+        return reader;
+    }
+
+
+    @Bean
+    public Job dailyReturnJob(Step dailyReturnStep) {
+        return jobs.get("dailyReturnJob")
+                .start(dailyReturnStep)
+                .build();
+    }
+
+    @Bean
+    public Step dailyReturnStep(MyBatisPagingItemReader<DailyReturn> reader) {
+        return steps.get("dailyReturnStep")
+                .<DailyReturn, DailyReturn>chunk(100)
+                .reader(reader)
+                .writer(writer)
+                .build();
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/job/investreturn/DailyBatch.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/investreturn/DailyBatch.java
@@ -1,0 +1,69 @@
+package woojooin.planitbatch.batch.job.investreturn;
+
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import woojooin.planitbatch.batch.writer.InvestMentWriter;
+import woojooin.planitbatch.domain.vo.InvestmentReturn;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+
+@Slf4j
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class DailyBatch {
+
+    private final JobBuilderFactory jobs;
+    private final StepBuilderFactory steps;
+    private final SqlSessionFactory sqlSessionFactory;
+    private final InvestMentWriter writer;
+
+
+    @Bean
+    @StepScope
+    public MyBatisPagingItemReader<InvestmentReturn> dailyReturnReader(
+            @Value("#{jobParameters['today']}") String todayStr)
+          {
+        MyBatisPagingItemReader<InvestmentReturn> reader = new MyBatisPagingItemReader<>();
+        reader.setSqlSessionFactory(sqlSessionFactory);
+        reader.setQueryId("woojooin.planitbatch.domain.mapper.InvestmentReturnMapper.findDailyReturn");
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("today", LocalDate.parse(todayStr));
+
+        reader.setParameterValues(parameters);
+        reader.setPageSize(100);
+
+        return reader;
+    }
+
+    @Bean
+    public Step dailybatchStep(MyBatisPagingItemReader<InvestmentReturn> dailyReturnReader) {
+        return steps.get("dailybatchStep")
+                .<InvestmentReturn, InvestmentReturn>chunk(100)
+                .reader(dailyReturnReader)
+                .writer(writer)
+                .build();
+    }
+
+    @Bean
+    public Job dailybatchJob(Step dailybatchStep) {
+        return jobs.get("dailybatchJob")
+                .start(dailybatchStep)
+                .build();
+    }
+
+}
+

--- a/src/main/java/woojooin/planitbatch/batch/job/investreturn/DailyReturnBatchJob.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/investreturn/DailyReturnBatchJob.java
@@ -1,4 +1,4 @@
-package woojooin.planitbatch.batch.job;
+package woojooin.planitbatch.batch.job.investreturn;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.ibatis.session.SqlSessionFactory;

--- a/src/main/java/woojooin/planitbatch/batch/job/investreturn/DailyReturnBatchJob.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/investreturn/DailyReturnBatchJob.java
@@ -40,7 +40,6 @@ public class DailyReturnBatchJob {
 
         reader.setSqlSessionFactory(sqlSessionFactory);
         reader.setQueryId("woojooin.planitbatch.domain.mapper.DailyReturnMapper.findAllForToday");
-
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("date", LocalDate.parse(dateStr));
         reader.setParameterValues(parameters);

--- a/src/main/java/woojooin/planitbatch/batch/job/investreturn/MonthlyBatch.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/investreturn/MonthlyBatch.java
@@ -1,0 +1,70 @@
+package woojooin.planitbatch.batch.job.investreturn;
+
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import woojooin.planitbatch.batch.writer.InvestMentWriter;
+import woojooin.planitbatch.batch.writer.InvestMonthlyWriter;
+import woojooin.planitbatch.domain.vo.InvestmentReturn;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+
+@Slf4j
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class MonthlyBatch {
+
+    private final JobBuilderFactory jobs;
+    private final StepBuilderFactory steps;
+    private final SqlSessionFactory sqlSessionFactory;
+    private final InvestMonthlyWriter  writer;
+
+    @Bean
+    @StepScope
+    public MyBatisPagingItemReader<InvestmentReturn> monthlyReturnReader(
+            @Value("#{jobParameters['today']}") String todayStr)
+    {
+        MyBatisPagingItemReader<InvestmentReturn> reader = new MyBatisPagingItemReader<>();
+        reader.setSqlSessionFactory(sqlSessionFactory);
+        reader.setQueryId("woojooin.planitbatch.domain.mapper.InvestmentReturnMapper.findMonthlyReturn");
+        log.info(" Reader 생성 - today={} " , todayStr );
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("today", LocalDate.parse(todayStr));
+
+        reader.setParameterValues(parameters);
+        reader.setPageSize(100);
+
+        return reader;
+    }
+
+    @Bean
+    public Step monthlybatchStep(MyBatisPagingItemReader<InvestmentReturn> monthlyReturnReader) {
+        return steps.get("monthlybatchStep")
+                .<InvestmentReturn, InvestmentReturn>chunk(100)
+                .reader(monthlyReturnReader)
+                .writer(writer)
+                .build();
+    }
+
+    @Bean
+    public Job monthlybatchJob(Step monthlybatchStep) {
+        return jobs.get("monthlybatchJob")
+                .start(monthlybatchStep)
+                .build();
+    }
+
+}
+

--- a/src/main/java/woojooin/planitbatch/batch/job/investreturn/PastBatch.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/investreturn/PastBatch.java
@@ -1,0 +1,70 @@
+package woojooin.planitbatch.batch.job.investreturn;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import woojooin.planitbatch.batch.writer.DailyReturnWriter;
+import woojooin.planitbatch.domain.vo.DailyReturn;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableBatchProcessing
+@Slf4j
+@RequiredArgsConstructor
+public class PastBatch {
+    private final JobBuilderFactory jobs;
+    private final StepBuilderFactory steps;
+    private final DailyReturnWriter writer;
+    private final SqlSessionFactory sqlSessionFactory;
+
+
+    @Bean
+    @StepScope
+    public MyBatisPagingItemReader<DailyReturn> etfDailyReader(
+            @Value("#{jobParameters['startDate']}") String startDate,
+            @Value("#{jobParameters['endDate']}") String endDate)  {
+
+        MyBatisPagingItemReader<DailyReturn> reader = new MyBatisPagingItemReader<>();
+        log.info("Reader 생성됨 - startDate={}, endDate={}", startDate, endDate); // 추가 로그
+        reader.setSqlSessionFactory(sqlSessionFactory);
+        reader.setQueryId("woojooin.planitbatch.domain.mapper.DailyReturnMapper.findpast");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("startDate", LocalDate.parse(startDate));
+        parameters.put("endDate", LocalDate.parse(endDate));
+        reader.setParameterValues(parameters);
+        reader.setPageSize(100);
+
+        return reader;
+    }
+
+
+    @Bean
+    public Job etfDailyReturnJob(Step etfDailyReturnStep) {
+        return jobs.get("etfDailyReturnJob")
+                .start(etfDailyReturnStep)
+                .build();
+    }
+
+    @Bean
+    public Step etfDailyReturnStep(MyBatisPagingItemReader<DailyReturn> etfDailyReader) {
+        return steps.get("etfDailyReturnStep")
+                .<DailyReturn, DailyReturn>chunk(100)
+                .reader(etfDailyReader)
+                .writer(writer)
+                .build();
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/job/investreturn/WeeklyBatch.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/investreturn/WeeklyBatch.java
@@ -1,0 +1,68 @@
+package woojooin.planitbatch.batch.job.investreturn;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.batch.MyBatisPagingItemReader;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import woojooin.planitbatch.batch.writer.InvestMentWriter;
+import woojooin.planitbatch.domain.vo.InvestmentReturn;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+@Slf4j
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class WeeklyBatch {
+    private final JobBuilderFactory jobs;
+    private final StepBuilderFactory steps;
+    private final SqlSessionFactory sqlSessionFactory;
+    private final InvestMentWriter writer;
+
+    @Bean
+    @StepScope
+    public MyBatisPagingItemReader<InvestmentReturn> weeklyReturnReader(
+            @Value("#{jobParameters['today']}") String todayStr ){
+
+        MyBatisPagingItemReader<InvestmentReturn> reader = new MyBatisPagingItemReader<>();
+        reader.setSqlSessionFactory(sqlSessionFactory);
+        reader.setQueryId("woojooin.planitbatch.domain.mapper.InvestmentReturnMapper.findWeeklyReturn");
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("today", LocalDate.parse(todayStr));
+        reader.setParameterValues(parameters);
+        reader.setPageSize(100);
+
+        return reader;
+    }
+
+    @Bean
+
+    public Job WeeklyBatchJob(Step WeeklyBatchStep) {
+        return jobs.get("WeeklyBatchJob")
+                .start(WeeklyBatchStep)
+                .build();
+
+    }
+
+    @Bean
+
+    public Step WeeklyBatchStep(MyBatisPagingItemReader<InvestmentReturn> weeklyReturnReader) {
+        return steps.get("WeeklyBatchStep")
+                .<InvestmentReturn, InvestmentReturn>chunk(100)
+                .reader(weeklyReturnReader)
+                .writer(writer)
+                .build();
+    }
+
+}
+
+

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/DailyReturnScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/DailyReturnScheduler.java
@@ -1,0 +1,32 @@
+package woojooin.planitbatch.batch.scheduler.investreturn;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class DailyReturnScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job dailyReturnJob;
+
+    @Scheduled(cron = "0 10 00 * * ?")
+    public void runDailyReturnJob() throws Exception {
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("date", LocalDate.now().toString())
+//                .addString("date", "2025-08-05") // 목데이터 날짜
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        jobLauncher.run(dailyReturnJob, jobParameters);
+    }
+}
+

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/DailyScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/DailyScheduler.java
@@ -1,0 +1,61 @@
+package woojooin.planitbatch.batch.scheduler.investreturn;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+import static woojooin.planitbatch.batch.scheduler.investreturn.PastScheduler.FORMATTER;
+
+@Component
+@RequiredArgsConstructor
+public class DailyScheduler {
+
+    private final JobLauncher jobLauncher;
+
+    @Qualifier("dailybatchJob")
+    private final Job dailybatchJob;
+
+    @Scheduled(cron = "0 20 00 * * ?")
+    public void runDailyReturnJob() throws Exception {
+        LocalDate today = LocalDate.now();
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("today", today.toString())         // 예: "2025-08-06"
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        jobLauncher.run(dailybatchJob, jobParameters);
+
+//       과거 etf 그래프에서 만든 자료
+
+//        LocalDate startDate = LocalDate.of(2024, 8, 5);
+//        LocalDate endDate = LocalDate.of(2025, 8, 5);
+//
+//        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+//            String dateStr = date.format(FORMATTER);
+//            System.out.println("▶ " + dateStr + " 배치 시작");
+//
+//            JobParameters jobParameters = new JobParametersBuilder()
+//                    .addString("today", dateStr)
+//                    .addLong("time", System.currentTimeMillis())  // JobInstance 중복 방지
+//                    .toJobParameters();
+//
+//            jobLauncher.run(dailybatchJob, jobParameters);
+//        }
+    }
+}
+
+
+
+
+
+
+
+

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/MonthlyScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/MonthlyScheduler.java
@@ -1,0 +1,65 @@
+package woojooin.planitbatch.batch.scheduler.investreturn;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyScheduler {
+
+    private final JobLauncher jobLauncher;
+
+    @Qualifier("monthlybatchJob")
+    private final Job monthlybatchJob;
+
+    private static final DateTimeFormatter FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    @Scheduled(cron = "0 30 0 L * ?")
+    public void runMonthlyReturnJob() throws Exception {
+        LocalDate today = LocalDate.now(); // 예: 2025-09-01
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("today", today.toString())
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        jobLauncher.run(monthlybatchJob, jobParameters);
+    }
+}
+
+//과거 etf 저료 넣은 것
+//        LocalDate startDate = LocalDate.of(2024, 8, 5);
+//        LocalDate endDate = LocalDate.of(2025, 8, 5);
+//
+//        LocalDate current = startDate.with(TemporalAdjusters.firstDayOfNextMonth());
+//        if (startDate.getDayOfMonth() == 1) {
+//            current = startDate;
+//        }
+//
+//        for (; !current.isAfter(endDate); current = current.plusMonths(1)) {
+//            // 그 달의 마지막 날로 재조정
+//            LocalDate lastOfMonth = current.with(TemporalAdjusters.lastDayOfMonth());
+//            String dateStr = lastOfMonth.format(FORMATTER);
+//            System.out.println("▶ 월별 기준 날짜: " + dateStr + " 배치 시작");
+//
+//            var params = new JobParametersBuilder()
+//                    .addString("today", dateStr)
+//                    .addLong("time", System.currentTimeMillis())
+//                    .toJobParameters();
+//
+//            jobLauncher.run(monthlybatchJob, params);
+//        }
+//    }
+
+//}

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/PastScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/PastScheduler.java
@@ -1,0 +1,44 @@
+package woojooin.planitbatch.batch.scheduler.investreturn;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@RequiredArgsConstructor
+public class PastScheduler {
+
+    private final JobLauncher jobLauncher;
+
+    @Qualifier("etfDailyReturnJob")
+    private final Job etfDailyReturnJob;
+
+
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+//    @Scheduled(cron = "0 20 19 * * ?")  //
+    public void runDailyReturnJob() throws Exception {
+        LocalDate startDate = LocalDate.of(2024, 8, 5);
+        LocalDate endDate = LocalDate.of(2025, 8, 5);
+
+        for (LocalDate date = startDate; !date.isAfter(endDate); date = date.plusDays(1)) {
+            String dateStr = date.format(FORMATTER);
+            System.out.println("▶  " + dateStr + " 배치 시작");
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("startDate", dateStr)
+                    .addString("endDate", dateStr)  // 하루 단위
+                    .addLong("time", System.currentTimeMillis())  // JobInstance 중복 방지
+                    .toJobParameters();
+
+            jobLauncher.run(etfDailyReturnJob, jobParameters);
+        }
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/WeeklyScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/investreturn/WeeklyScheduler.java
@@ -1,0 +1,58 @@
+package woojooin.planitbatch.batch.scheduler.investreturn;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+import static woojooin.planitbatch.batch.scheduler.investreturn.PastScheduler.FORMATTER;
+
+@Component
+@RequiredArgsConstructor
+public class WeeklyScheduler {
+    private final JobLauncher jobLauncher;
+
+    @Qualifier("WeeklyBatchJob")
+    private final Job WeeklyBatchJob;
+
+
+    @Scheduled(cron = "0 40 0 ? * MON")
+    public void runWeeklyBatchJob() throws JobExecutionException {
+        LocalDate today = LocalDate.now();
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("today",today.toString())
+                .addLong("time", System.currentTimeMillis())
+                .toJobParameters();
+
+        jobLauncher.run(WeeklyBatchJob, jobParameters);
+
+        //과거 etf 위클리 배치
+//        LocalDate startDate = LocalDate.of(2024, 8, 5);
+//        LocalDate endDate = LocalDate.of(2025, 8, 5);
+//        LocalDate firstMonday = startDate.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
+//
+//        for (LocalDate date = firstMonday; !date.isAfter(endDate); date = date.plusWeeks(1)) {
+//            String dateStr = date.format(FORMATTER);
+//            System.out.println("▶ 주차 기준 날짜: " + dateStr + " 배치 시작");
+//
+//            var params = new JobParametersBuilder()
+//                    .addString("today", dateStr)
+//                    .addLong("time", System.currentTimeMillis())
+//                    .toJobParameters();
+//
+//            jobLauncher.run(WeeklyBatchJob, params);
+        }
+    }
+
+
+

--- a/src/main/java/woojooin/planitbatch/batch/writer/DailyReturnWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/DailyReturnWriter.java
@@ -1,0 +1,28 @@
+package woojooin.planitbatch.batch.writer;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import woojooin.planitbatch.domain.mapper.DailyReturnMapper;
+import woojooin.planitbatch.domain.vo.DailyReturn;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DailyReturnWriter implements ItemWriter<DailyReturn> {
+    private final SqlSessionFactory sqlSessionFactory;
+
+    @Override
+    public void write(List<? extends DailyReturn> items) {
+        try (SqlSession session = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
+            for (DailyReturn item : items) {
+                session.insert("woojooin.planitbatch.domain.mapper.DailyReturnMapper.insert", item);
+            }
+            session.flushStatements();
+        }
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/writer/InvestMentWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/InvestMentWriter.java
@@ -1,0 +1,43 @@
+package woojooin.planitbatch.batch.writer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import woojooin.planitbatch.domain.vo.InvestmentReturn;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InvestMentWriter implements ItemWriter<InvestmentReturn> {
+
+    private final SqlSessionFactory sqlSessionFactory;
+
+    @Override
+    public void write(List<? extends InvestmentReturn> items) throws Exception {
+        try (SqlSession session = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
+            log.info("▶ Writer 실행됨. item 수: {}", items.size());
+            for(InvestmentReturn item : items) {
+                if(item.getAmountPast() != null&&item.getAmountPast().compareTo(BigDecimal.ZERO)>0) {
+                    BigDecimal rate = item.getAmountNow()
+                            .subtract(item.getAmountPast())
+                            .divide(item.getAmountPast(), 4, RoundingMode.HALF_UP)
+                            .multiply(new BigDecimal("100"));
+                    item.setReturnRate(rate);
+                } else {
+                    item.setReturnRate(BigDecimal.ZERO); // 과거 금액이 0이면 0%
+                }
+                session.insert("woojooin.planitbatch.domain.mapper.InvestmentReturnMapper.insert", item);
+            }
+            session.flushStatements(); // 모든 INSERT 실행
+        }
+    }
+}
+

--- a/src/main/java/woojooin/planitbatch/batch/writer/InvestMonthlyWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/InvestMonthlyWriter.java
@@ -1,0 +1,43 @@
+package woojooin.planitbatch.batch.writer;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+import woojooin.planitbatch.domain.vo.InvestmentReturn;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InvestMonthlyWriter implements ItemWriter<InvestmentReturn>{
+
+    private final SqlSessionFactory sqlSessionFactory;
+
+    @Override
+    public void write(List<? extends InvestmentReturn> items) throws Exception {
+        try (SqlSession session = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
+            log.info("▶ Writer 실행됨. item 수: {}", items.size());
+            for(InvestmentReturn item : items) {
+                if(item.getAmountPast() != null&&item.getAmountPast().compareTo(BigDecimal.ZERO)>0) {
+                    BigDecimal rate = item.getAmountNow()
+                            .subtract(item.getAmountPast())
+                            .divide(item.getAmountPast(), 4, RoundingMode.HALF_UP)
+                            .multiply(new BigDecimal("100"));
+                    item.setReturnRate(rate);
+                } else {
+                    item.setReturnRate(BigDecimal.ZERO); // 과거 금액이 0이면 0%
+                }
+                session.insert("woojooin.planitbatch.domain.mapper.InvestmentReturnMapper.upsertMonthlyReturn", item);
+            }
+            session.flushStatements(); // 모든 INSERT 실행
+        }
+    }
+}

--- a/src/main/java/woojooin/planitbatch/domain/mapper/DailyReturnMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/DailyReturnMapper.java
@@ -1,0 +1,12 @@
+package woojooin.planitbatch.domain.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import woojooin.planitbatch.domain.vo.DailyReturn;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DailyReturnMapper {
+    List<DailyReturn> findAllForToday(@Param("date")LocalDate date);
+    void insert(DailyReturn dailyReturn);
+}

--- a/src/main/java/woojooin/planitbatch/domain/mapper/DailyReturnMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/DailyReturnMapper.java
@@ -8,5 +8,10 @@ import java.util.List;
 
 public interface DailyReturnMapper {
     List<DailyReturn> findAllForToday(@Param("date")LocalDate date);
+
+    List<DailyReturn> findpast(@Param("startDate") LocalDate startDate,
+                               @Param("endDate") LocalDate endDate);
+
+
     void insert(DailyReturn dailyReturn);
 }

--- a/src/main/java/woojooin/planitbatch/domain/mapper/InvestmentReturnMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/InvestmentReturnMapper.java
@@ -1,0 +1,22 @@
+package woojooin.planitbatch.domain.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.springframework.cglib.core.Local;
+import woojooin.planitbatch.domain.vo.DailyReturn;
+import woojooin.planitbatch.domain.vo.InvestmentReturn;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface InvestmentReturnMapper {
+    List<InvestmentReturn> findDailyReturn(@Param("today") LocalDate today);
+    List<InvestmentReturn> findWeeklyReturn(@Param("today") LocalDate today);
+    List<InvestmentReturn>findMonthlyReturn(@Param("today") LocalDate today);
+    void insert(InvestmentReturn returnResult);
+    void upsertMonthlyReturn(InvestmentReturn returnResult);
+
+}
+
+
+
+

--- a/src/main/java/woojooin/planitbatch/domain/vo/DailyReturn.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/DailyReturn.java
@@ -1,0 +1,18 @@
+package woojooin.planitbatch.domain.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyReturn {
+    private Long memberId;
+    private String itemCode;
+    private LocalDate returnDate;
+    private BigDecimal amount;
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/InvestmentReturn.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/InvestmentReturn.java
@@ -1,0 +1,20 @@
+package woojooin.planitbatch.domain.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class InvestmentReturn {
+    private Long memberId;
+    private String returnType;
+    private LocalDate returnDate;
+    private BigDecimal amountNow;
+    private BigDecimal amountPast;
+    private BigDecimal returnRate;
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/ProductDto.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/ProductDto.java
@@ -1,0 +1,21 @@
+package woojooin.planitbatch.domain.vo;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public class ProductDto {
+
+    /** 상품코드 */
+    private String productIdentifier;
+
+    /** 상품명 */
+    private String productName;
+
+    /** 기준일자 */
+    private LocalDate baseDate;
+
+    /** 종가 */
+    private BigDecimal closingPrice;
+
+
+}

--- a/src/main/resources/mapper/DailyReturnMapper.xml
+++ b/src/main/resources/mapper/DailyReturnMapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="woojooin.planitbatch.domain.mapper.DailyReturnMapper">
+    <select id="findAllForToday" resultType="woojooin.planitbatch.domain.vo.DailyReturn">
+        SELECT
+            mp.member_id AS memberId,
+            mp.product_id AS itemCode,
+            p.bas_dt AS returnDate,
+            CAST(p.clpr AS DECIMAL(20,2)) * mp.quantity AS amount
+        FROM member_product mp
+                 JOIN product p ON mp.product_id COLLATE utf8mb4_unicode_ci = p.isin_cd COLLATE utf8mb4_unicode_ci
+        WHERE DATE(p.bas_dt) = #{date}
+    </select>
+
+
+    <select id="insert" parameterType="woojooin.planitbatch.domain.vo.DailyReturn">
+        INSERT INTO daily_return (member_id, item_code, return_date, amount)
+        VALUES (#{memberId}, #{itemCode}, #{returnDate}, #{amount})
+    </select>
+</mapper>
+

--- a/src/main/resources/mapper/DailyReturnMapper.xml
+++ b/src/main/resources/mapper/DailyReturnMapper.xml
@@ -7,11 +7,24 @@
         SELECT
             mp.member_id AS memberId,
             mp.product_id AS itemCode,
-            p.bas_dt AS returnDate,
-            CAST(p.clpr AS DECIMAL(20,2)) * mp.quantity AS amount
+            p.base_date AS returnDate,
+            sum(CAST(p.closing_price AS DECIMAL(20,2)) * mp.quantity )AS amount
         FROM member_product mp
-                 JOIN product p ON mp.product_id COLLATE utf8mb4_unicode_ci = p.isin_cd COLLATE utf8mb4_unicode_ci
-        WHERE DATE(p.bas_dt) = #{date}
+        JOIN product p ON mp.product_id COLLATE utf8mb4_unicode_ci = p.shorten_code COLLATE utf8mb4_unicode_ci
+        WHERE DATE(p.base_date) = #{date}
+        GROUP BY mp.member_id, mp.product_id, p.base_date
+    </select>
+
+    <select id="findpast" resultType="woojooin.planitbatch.domain.vo.DailyReturn">
+        select
+            mp.member_id AS memberId,
+            mp.product_id AS itemCode,
+            edh.base_date AS returnDate,
+            CAST(edh.closing_price AS DECIMAL(20, 2))* mp.quantity AS amount
+        from etf_daily_history edh
+            join member_product mp ON mp.product_id = edh.shorten_code
+        WHERE edh.base_date BETWEEN #{startDate} AND #{endDate}
+        ORDER BY edh.base_date, mp.member_id
     </select>
 
 

--- a/src/main/resources/mapper/InvestmentReturnMapper.xml
+++ b/src/main/resources/mapper/InvestmentReturnMapper.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="woojooin.planitbatch.domain.mapper.InvestmentReturnMapper">
+
+    <select id="findDailyReturn" resultType="woojooin.planitbatch.domain.vo.InvestmentReturn">
+        SELECT
+            today.member_id AS memberId,
+            #{today} AS returnDate,
+            'DAILY' AS returnType,
+            today.amount AS amountNow,
+            IFNULL(yesterday.amount, 0) AS amountPast
+        FROM (
+                 SELECT member_id, SUM(amount) AS amount
+                 FROM daily_return
+                 WHERE return_date = #{today}
+                 GROUP BY member_id
+             ) today
+                 LEFT JOIN (
+            SELECT member_id, SUM(amount) AS amount
+            FROM daily_return
+            WHERE return_date = DATE_SUB(#{today}, INTERVAL 1 DAY)
+            GROUP BY member_id
+        ) yesterday ON today.member_id = yesterday.member_id
+    </select>
+
+    <select id="findWeeklyReturn" resultType="woojooin.planitbatch.domain.vo.InvestmentReturn">
+        SELECT
+            this_week.member_id AS memberId,
+            #{today} AS returnDate,
+            'WEEKLY' AS returnType,
+            this_week.amount AS amountNow,
+            IFNULL(last_week.amount, 0) AS amountPast
+        FROM (
+                 SELECT member_id, SUM(amount) AS amount
+                 FROM daily_return
+                 WHERE return_date = #{today}
+                 GROUP BY member_id
+             ) this_week
+                 LEFT JOIN (
+            SELECT member_id, SUM(amount) AS amount
+            FROM daily_return
+            WHERE return_date = DATE_SUB(#{today}, INTERVAL 7 DAY)
+            GROUP BY member_id
+        ) last_week ON this_week.member_id = last_week.member_id
+    </select>
+
+
+    <select id="findMonthlyReturn" resultType="woojooin.planitbatch.domain.vo.InvestmentReturn">
+        SELECT
+            this_month.member_id AS memberId,
+            #{today} AS returnDate,
+            'MONTHLY' AS returnType,
+            this_month.amount AS amountNow,
+            IFNULL(last_month.amount, 0) AS amountPast
+        FROM (
+                 SELECT member_id, SUM(amount) AS amount
+                 FROM daily_return
+                 WHERE return_date = #{today}
+                 GROUP BY member_id
+             ) this_month
+                 LEFT JOIN (
+            SELECT member_id, SUM(amount) AS amount
+            FROM daily_return
+            WHERE return_date = LAST_DAY(DATE_SUB(#{today}, INTERVAL 1 MONTH))
+            GROUP BY member_id
+        ) last_month ON this_month.member_id = last_month.member_id
+    </select>
+
+    <insert id="insert" parameterType="woojooin.planitbatch.domain.vo.InvestmentReturn">
+        INSERT INTO investment_return (member_id, return_type, return_date, return_rate, amount_now, amount_past)
+        VALUES (#{memberId}, #{returnType}, #{returnDate}, #{returnRate}, #{amountNow}, #{amountPast})
+    </insert>
+
+    <insert id="upsertMonthlyReturn" parameterType="woojooin.planitbatch.domain.vo.InvestmentReturn">
+        INSERT INTO investment_return
+        (member_id, return_type, return_date, amount_now, amount_past, return_rate)
+        VALUES
+            (#{memberId}, 'MONTHLY', #{returnDate},
+             #{amountNow}, #{amountPast}, #{returnRate})
+            ON DUPLICATE KEY UPDATE
+                                 amount_now  = VALUES(amount_now),
+                                 amount_past = VALUES(amount_past),
+                                 return_rate = VALUES(return_rate)
+    </insert>
+</mapper>
+


### PR DESCRIPTION
## 🔖 PR 유형
- [👽] ✨ 기능 추가
- [ ] 🐛 버그 수정
- [ ] ♻️ 리팩토링
- [ ] 🧪 테스트 코드 추가
- [ ] 📄 문서 수정
- [ ] 기타

## 📌 개요
리포트 페이지 투자 부분 수익률 막대그래프 

## 🔧 작업 내용
- member_product 랑 최신 product 시세에 따라 다른 ( 수량 * 가격 ) 을  일,주,월 비교해서 수익률 비교 
-  past스케줄러로 etf_history 테이블 내용 가져와서 테이블 채움  

## ✅ 체크리스트
- [ ] 테스트 완료(Postman, Swagger)

## 📝 기타 참고 사항
- 주의할 점, 추후 리팩토링 필요성 등
배치지옥탈출 
- 위클리 : 전 주 월요일날 자료 없으면 비교 못해서 수익률 0 
- 먼슬리 : 달 마지막 날끼리 비교하는데 말 일에 자료 없으면 비교못해서  수익률 0 
- 데일리 : 그 전 날 amout 없으면 수익률 비교 못해서 0

## 📎 관련 이슈
Close #18
