### PR TITLE
[FEAT] 투자금 총액 배치 - 충돌 해결

### DIFF
--- a/src/main/java/woojooin/planitbatch/batch/job/BatchConfig.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/BatchConfig.java
@@ -31,14 +31,16 @@ public class BatchConfig {
 	private DepositProcessor depositProcessor;
 	@Autowired
 	private DepositWriter depositWriter;
-	
+
 	@Autowired
+	private StepBuilderFactory steps;
+
 	private TaxCalculationReader taxCalculationReader;
 	@Autowired
 	private TaxCalculationProcessor taxCalculationProcessor;
 	@Autowired
 	private TaxCalculationWriter taxCalculationWriter;
-	
+
 	@Autowired
 	@Qualifier("batchTransactionManager")  // 명시적 트랜잭션 매니저 지정
 	private PlatformTransactionManager transactionManager;

--- a/src/main/java/woojooin/planitbatch/batch/job/totalInvestAmount/DailyInvestAmountJob.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/totalInvestAmount/DailyInvestAmountJob.java
@@ -1,0 +1,49 @@
+package woojooin.planitbatch.batch.job.totalInvestAmount;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import woojooin.planitbatch.batch.processor.totalInvestProcessor.DailyInvestAmountProcessor;
+import woojooin.planitbatch.batch.reader.totalInvestAmountReader.DailyInvestAmountReader;
+import woojooin.planitbatch.batch.writer.totalInvestAmountWriter.DailyInvestAmountWriter;
+import woojooin.planitbatch.domain.vo.DailyInvestSummaryVo;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MemberVo;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class DailyInvestAmountJob {
+    @Autowired
+    private  JobBuilderFactory jobBuilderFactory;
+    @Autowired
+    private  StepBuilderFactory stepBuilderFactory;
+    @Autowired
+    private DailyInvestAmountReader dailyInvestAmountReader;
+    @Autowired
+    private DailyInvestAmountProcessor dailyInvestAmountProcessor;
+
+    private final DailyInvestAmountWriter dailyInvestAmountWriter;
+
+    @Bean
+    public Job dailyInvestJob() {
+        return jobBuilderFactory.get("dailyInvestAmountJob")
+                .start(dailyInvestAmountStep())
+                .build();
+    }
+
+    @Bean
+    public Step dailyInvestAmountStep() {
+        return stepBuilderFactory.get("dailyInvestAmountStep")
+                .<MemberVo, DailyInvestSummaryVo>chunk(1000)
+                .reader(dailyInvestAmountReader)
+                .processor(dailyInvestAmountProcessor)
+                .writer(dailyInvestAmountWriter)
+                .build();
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/job/totalInvestAmount/MonthlyInvestAmountJob.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/totalInvestAmount/MonthlyInvestAmountJob.java
@@ -1,0 +1,45 @@
+package woojooin.planitbatch.batch.job.totalInvestAmount;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import woojooin.planitbatch.batch.processor.totalInvestProcessor.MonthlyInvestAmountProcessor;
+import woojooin.planitbatch.batch.reader.totalInvestAmountReader.MonthlyInvestAmountReader;
+import woojooin.planitbatch.batch.writer.totalInvestAmountWriter.MonthlyInvestAmountWriter;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MonthlyInvestSummaryVo;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo;
+
+import java.util.List;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class MonthlyInvestAmountJob {
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final MonthlyInvestAmountReader monthlyInvestAmountReader;
+     private final MonthlyInvestAmountProcessor monthlyInvestAmountProcessor;
+     private final MonthlyInvestAmountWriter monthlyInvestAmountWriter;
+
+     @Bean
+    public Job monthlyInvestJob() {
+        return jobBuilderFactory.get("monthlyInvestAmountJob")
+                .start(monthlyInvestAmountStep())
+                .build();
+    }
+
+    @Bean
+    public Step monthlyInvestAmountStep() {
+        return stepBuilderFactory.get("monthlyInvestAmountStep")
+                .<List<WeeklyInvestSummaryVo>, MonthlyInvestSummaryVo>chunk(1000)
+                .reader(monthlyInvestAmountReader)
+                .processor(monthlyInvestAmountProcessor)
+                .writer(monthlyInvestAmountWriter)
+                .build();
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/job/totalInvestAmount/WeeklyInvestAmountJob.java
+++ b/src/main/java/woojooin/planitbatch/batch/job/totalInvestAmount/WeeklyInvestAmountJob.java
@@ -1,0 +1,45 @@
+package woojooin.planitbatch.batch.job.totalInvestAmount;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.JobBuilderFactory;
+import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import woojooin.planitbatch.batch.processor.totalInvestProcessor.WeeklyInvestAmountProcessor;
+import woojooin.planitbatch.batch.reader.totalInvestAmountReader.WeeklyInvestAmountReader;
+import woojooin.planitbatch.batch.writer.totalInvestAmountWriter.WeeklyInvestAmountWriter;
+import woojooin.planitbatch.domain.vo.DailyInvestSummaryVo;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo;
+
+import java.util.List;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class WeeklyInvestAmountJob {
+    private final JobBuilderFactory jobBuilderFactory;
+    private final StepBuilderFactory stepBuilderFactory;
+    private final WeeklyInvestAmountReader weeklyInvestAmountReader;
+    private final WeeklyInvestAmountProcessor weeklyInvestAmountProcessor;
+    private final WeeklyInvestAmountWriter weeklyInvestAmountWriter;
+
+    @Bean
+    public Job weeklyInvestJob() {
+        return jobBuilderFactory.get("weeklyInvestAmountJob")
+                .start(weeklyInvestAmountStep())
+                .build();
+    }
+
+    @Bean
+    public Step weeklyInvestAmountStep() {
+        return stepBuilderFactory.get("weeklyInvestAmountStep")
+                .<List<DailyInvestSummaryVo>, WeeklyInvestSummaryVo>chunk(1000)
+                .reader(weeklyInvestAmountReader)
+                .processor(weeklyInvestAmountProcessor)
+                .writer(weeklyInvestAmountWriter)
+                .build();
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/DailyInvestAmountProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/DailyInvestAmountProcessor.java
@@ -1,0 +1,65 @@
+package woojooin.planitbatch.batch.processor.totalInvestProcessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import woojooin.planitbatch.domain.vo.DailyInvestSummaryVo;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MemberVo;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MemberProductVo;
+
+import org.springframework.batch.item.ItemProcessor;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.*;
+
+@Slf4j
+@Component
+public class DailyInvestAmountProcessor implements ItemProcessor<MemberVo, DailyInvestSummaryVo> {
+
+    @Override
+    public DailyInvestSummaryVo process(MemberVo member) throws Exception {
+        if (member == null || member.getProducts() == null || member.getProducts().isEmpty()) {
+            return null;
+        }
+          Map<String, BigDecimal> dailyAmountMap = new HashMap<>();
+          Map<String, Long> dailyCountMap = new HashMap<>();
+
+
+        for (MemberProductVo product : member.getProducts()) {
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(product.getUpdatedAt());
+
+            String dailyKey = String.format("%d-%02d-%02d",
+                    cal.get(Calendar.YEAR),
+                    cal.get(Calendar.MONTH) + 1,
+                    cal.get(Calendar.DAY_OF_MONTH));
+
+            BigDecimal totalAmount = product.getPurchaseAmount().multiply(product.getQuantity());
+
+            dailyAmountMap.merge(dailyKey, totalAmount, BigDecimal::add);
+            dailyCountMap.merge(dailyKey, 1L, Long::sum);
+        }
+
+        DailyInvestSummaryVo summaryVo = new DailyInvestSummaryVo();
+        summaryVo.setMemberId(member.getMemberId());
+
+        if (!dailyAmountMap.isEmpty()) {
+            String latestDate = dailyAmountMap.keySet().stream()
+                    .max(String::compareTo)
+                    .orElse("");
+
+            summaryVo.setDailyTotal(dailyAmountMap.getOrDefault(latestDate, BigDecimal.ZERO));
+            summaryVo.setDailyCount(dailyCountMap.getOrDefault(latestDate, 0L).intValue());
+        } else {
+            summaryVo.setDailyTotal(BigDecimal.ZERO);
+            summaryVo.setDailyCount(0);
+        }
+
+
+        summaryVo.setUpdatedAt(new Timestamp(System.currentTimeMillis()));
+
+        return summaryVo;
+    }
+
+    }
+

--- a/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/DailyInvestAmountProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/DailyInvestAmountProcessor.java
@@ -23,6 +23,7 @@ public class DailyInvestAmountProcessor implements ItemProcessor<MemberVo, Daily
         }
           Map<String, BigDecimal> dailyAmountMap = new HashMap<>();
           Map<String, Long> dailyCountMap = new HashMap<>();
+          Map<String, BigDecimal> dailyValuationMap = new HashMap<>();
 
 
         for (MemberProductVo product : member.getProducts()) {
@@ -35,8 +36,9 @@ public class DailyInvestAmountProcessor implements ItemProcessor<MemberVo, Daily
                     cal.get(Calendar.DAY_OF_MONTH));
 
             BigDecimal totalAmount = product.getPurchaseAmount().multiply(product.getQuantity());
-
+            BigDecimal valuationAmount = product.getValuationAmount().multiply(product.getQuantity());
             dailyAmountMap.merge(dailyKey, totalAmount, BigDecimal::add);
+            dailyValuationMap.merge(dailyKey, valuationAmount, BigDecimal::add);
             dailyCountMap.merge(dailyKey, 1L, Long::sum);
         }
 
@@ -49,9 +51,11 @@ public class DailyInvestAmountProcessor implements ItemProcessor<MemberVo, Daily
                     .orElse("");
 
             summaryVo.setDailyTotal(dailyAmountMap.getOrDefault(latestDate, BigDecimal.ZERO));
+            summaryVo.setDailyValuationTotal(dailyValuationMap.getOrDefault(latestDate, BigDecimal.ZERO));
             summaryVo.setDailyCount(dailyCountMap.getOrDefault(latestDate, 0L).intValue());
         } else {
             summaryVo.setDailyTotal(BigDecimal.ZERO);
+            summaryVo.setDailyValuationTotal(BigDecimal.ZERO);
             summaryVo.setDailyCount(0);
         }
 

--- a/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/MonthlyInvestAmountProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/MonthlyInvestAmountProcessor.java
@@ -1,0 +1,69 @@
+package woojooin.planitbatch.batch.processor.totalInvestProcessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MonthlyInvestSummaryVo;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.List;
+
+@Component
+@StepScope
+@Slf4j
+public class MonthlyInvestAmountProcessor implements ItemProcessor<List<WeeklyInvestSummaryVo>, MonthlyInvestSummaryVo> {
+    @Override
+    public MonthlyInvestSummaryVo process(List<WeeklyInvestSummaryVo> memberWeeklyList) throws Exception {
+        if (memberWeeklyList == null || memberWeeklyList.isEmpty()) {
+            return null;
+        }
+
+        WeeklyInvestSummaryVo firstRecord = memberWeeklyList.get(0);
+        Long memberId = firstRecord.getMemberId();
+
+        if (memberId == null) {
+            return null;
+        }
+
+
+        BigDecimal monthlyTotalAmount = BigDecimal.ZERO;
+        int monthlyTotalCount = 0;
+        int weeklyDataCount = 0;
+
+        for (WeeklyInvestSummaryVo weeklyData : memberWeeklyList) {
+            if (weeklyData.getWeeklyTotalAmount() == null) {
+                continue;
+            }
+
+            // 멤버 ID 일치 확인 (안전장치)
+            if (!memberId.equals(weeklyData.getMemberId())) {
+                log.warn("멤버 ID 불일치! 예상: {}, 실제: {} - 데이터 스킵", memberId, weeklyData.getMemberId());
+                continue;
+            }
+
+            monthlyTotalAmount = monthlyTotalAmount.add(weeklyData.getWeeklyTotalAmount());
+            monthlyTotalCount += weeklyData.getWeeklyTotalCount();
+            weeklyDataCount++;
+        }
+
+        if (weeklyDataCount == 0) {
+            log.debug("멤버 {} - 유효한 주간 데이터가 없음", memberId);
+            return null;
+        }
+        
+        MonthlyInvestSummaryVo monthlyMemberSummary = new MonthlyInvestSummaryVo();
+        monthlyMemberSummary.setMemberId(memberId);
+        monthlyMemberSummary.setMonthlyTotalAmount(monthlyTotalAmount);
+        monthlyMemberSummary.setMonthlyTotalCount(monthlyTotalCount);
+
+        Timestamp currentTime = new Timestamp(System.currentTimeMillis());
+        monthlyMemberSummary.setCreatedAt(currentTime);
+        monthlyMemberSummary.setUpdatedAt(currentTime);
+        monthlyMemberSummary.setIsDeleted(false);
+
+        return monthlyMemberSummary;
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/MonthlyInvestAmountProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/MonthlyInvestAmountProcessor.java
@@ -30,6 +30,7 @@ public class MonthlyInvestAmountProcessor implements ItemProcessor<List<WeeklyIn
 
 
         BigDecimal monthlyTotalAmount = BigDecimal.ZERO;
+        BigDecimal monthlyValuationTotal = BigDecimal.ZERO;
         int monthlyTotalCount = 0;
         int weeklyDataCount = 0;
 
@@ -45,6 +46,7 @@ public class MonthlyInvestAmountProcessor implements ItemProcessor<List<WeeklyIn
             }
 
             monthlyTotalAmount = monthlyTotalAmount.add(weeklyData.getWeeklyTotalAmount());
+            monthlyValuationTotal = monthlyValuationTotal.add(weeklyData.getWeeklyValuationTotal());
             monthlyTotalCount += weeklyData.getWeeklyTotalCount();
             weeklyDataCount++;
         }
@@ -57,6 +59,7 @@ public class MonthlyInvestAmountProcessor implements ItemProcessor<List<WeeklyIn
         MonthlyInvestSummaryVo monthlyMemberSummary = new MonthlyInvestSummaryVo();
         monthlyMemberSummary.setMemberId(memberId);
         monthlyMemberSummary.setMonthlyTotalAmount(monthlyTotalAmount);
+        monthlyMemberSummary.setMonthlyValuationTotal(monthlyValuationTotal);
         monthlyMemberSummary.setMonthlyTotalCount(monthlyTotalCount);
 
         Timestamp currentTime = new Timestamp(System.currentTimeMillis());

--- a/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/WeeklyInvestAmountProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/WeeklyInvestAmountProcessor.java
@@ -1,0 +1,73 @@
+package woojooin.planitbatch.batch.processor.totalInvestProcessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+import woojooin.planitbatch.domain.vo.DailyInvestSummaryVo;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
+
+@Component
+@StepScope
+@Slf4j
+public class WeeklyInvestAmountProcessor implements ItemProcessor<List<DailyInvestSummaryVo>, WeeklyInvestSummaryVo> {
+
+    @Override
+    public WeeklyInvestSummaryVo process(List<DailyInvestSummaryVo> memberDailyList) throws Exception {
+        if (memberDailyList == null || memberDailyList.isEmpty()) {
+            log.debug("빈 멤버 일별 데이터 리스트 - 스킵");
+            return null;
+        }
+
+        DailyInvestSummaryVo firstRecord = memberDailyList.get(0);
+        Long memberId = firstRecord.getMemberId();
+
+        if (memberId == null) {
+            log.debug("멤버 ID가 null인 데이터 - 스킵");
+            return null;
+        }
+
+        BigDecimal weeklyTotalAmount = BigDecimal.ZERO;
+        int weeklyTotalCount = 0;
+        int dailyDataCount = 0;
+
+        for (DailyInvestSummaryVo dailyData : memberDailyList) {
+            if (dailyData.getDailyTotal() == null) {
+                continue;
+            }
+
+            if (!memberId.equals(dailyData.getMemberId())) {
+                continue;
+            }
+
+            weeklyTotalAmount = weeklyTotalAmount.add(dailyData.getDailyTotal());
+            weeklyTotalCount += dailyData.getDailyCount();
+            dailyDataCount++;
+        }
+
+        // 처리된 데이터가 없으면 스킵
+        if (dailyDataCount == 0) {
+            return null;
+        }
+
+        WeeklyInvestSummaryVo weeklyMemberSummary = new WeeklyInvestSummaryVo();
+        weeklyMemberSummary.setMemberId(memberId);
+        weeklyMemberSummary.setWeeklyTotalAmount(weeklyTotalAmount);
+        weeklyMemberSummary.setWeeklyTotalCount(weeklyTotalCount);
+
+
+        Timestamp currentTime = new Timestamp(System.currentTimeMillis());
+        weeklyMemberSummary.setCreatedAt(currentTime);
+        weeklyMemberSummary.setUpdatedAt(currentTime);
+        weeklyMemberSummary.setIsDeleted(false);
+
+        return weeklyMemberSummary;
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/WeeklyInvestAmountProcessor.java
+++ b/src/main/java/woojooin/planitbatch/batch/processor/totalInvestProcessor/WeeklyInvestAmountProcessor.java
@@ -35,6 +35,7 @@ public class WeeklyInvestAmountProcessor implements ItemProcessor<List<DailyInve
         }
 
         BigDecimal weeklyTotalAmount = BigDecimal.ZERO;
+        BigDecimal weeklyValuationTotal = BigDecimal.ZERO;
         int weeklyTotalCount = 0;
         int dailyDataCount = 0;
 
@@ -48,6 +49,7 @@ public class WeeklyInvestAmountProcessor implements ItemProcessor<List<DailyInve
             }
 
             weeklyTotalAmount = weeklyTotalAmount.add(dailyData.getDailyTotal());
+            weeklyValuationTotal = weeklyValuationTotal.add(dailyData.getDailyValuationTotal());
             weeklyTotalCount += dailyData.getDailyCount();
             dailyDataCount++;
         }
@@ -61,7 +63,7 @@ public class WeeklyInvestAmountProcessor implements ItemProcessor<List<DailyInve
         weeklyMemberSummary.setMemberId(memberId);
         weeklyMemberSummary.setWeeklyTotalAmount(weeklyTotalAmount);
         weeklyMemberSummary.setWeeklyTotalCount(weeklyTotalCount);
-
+        weeklyMemberSummary.setWeeklyValuationTotal(weeklyValuationTotal);
 
         Timestamp currentTime = new Timestamp(System.currentTimeMillis());
         weeklyMemberSummary.setCreatedAt(currentTime);

--- a/src/main/java/woojooin/planitbatch/batch/reader/totalInvestAmountReader/DailyInvestAmountReader.java
+++ b/src/main/java/woojooin/planitbatch/batch/reader/totalInvestAmountReader/DailyInvestAmountReader.java
@@ -1,0 +1,128 @@
+package woojooin.planitbatch.batch.reader.totalInvestAmountReader;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import woojooin.planitbatch.domain.mapper.MemberProductMapper;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MemberVo;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@StepScope
+@Slf4j
+public class DailyInvestAmountReader implements ItemReader<MemberVo> {
+
+    private final MemberProductMapper memberProductMapper;
+
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+
+    private static final int PAGE_SIZE = 1000;
+    private int currentPage = 0;
+    private int currentIndex = 0;
+    private List<MemberVo> currentBatch;
+    private boolean hasMoreData = true;
+
+    public DailyInvestAmountReader(MemberProductMapper memberProductMapper) {
+        this.memberProductMapper = memberProductMapper;
+        log.info("MyBatisReader 초기화 완료");
+    }
+
+    @Override
+    public MemberVo read() throws Exception {
+        if (currentBatch == null || currentIndex >= currentBatch.size()) {
+            if (!hasMoreData) {
+                log.info("더 이상 읽을 데이터가 없습니다. 총 {}페이지 처리 완료", currentPage);
+                return null;
+            }
+
+            // 이전 배치 메모리 해제
+            if (currentBatch != null) {
+                currentBatch.clear();
+                currentBatch = null;
+            }
+
+            currentBatch = fetchNextBatch();
+            currentIndex = 0;
+
+            if (currentBatch == null || currentBatch.isEmpty()) {
+                log.info("배치 조회 완료 - 더 이상 데이터가 없습니다.");
+                hasMoreData = false;
+                return null;
+            }
+        }
+
+        // 현재 배치에서 다음 멤버 반환
+        MemberVo member = currentBatch.get(currentIndex++);
+
+        if (log.isDebugEnabled()) {
+            log.debug("처리 중인 멤버: {}, 상품 개수: {} (페이지: {}, 인덱스: {})",
+                    member.getMemberId(),
+                    member.getProducts() != null ? member.getProducts().size() : 0,
+                    currentPage, currentIndex - 1);
+        }
+
+        return member;
+    }
+
+    @Transactional(readOnly = true)
+    public List<MemberVo> fetchNextBatch() throws Exception {
+        try {
+            Map<String, Object> params = new HashMap<>();
+
+            String dateParam = getFormattedTargetDate();
+            params.put("targetDate", dateParam);
+
+
+            int offset = currentPage * PAGE_SIZE;
+            params.put("_skiprows", offset);
+            params.put("_pagesize", PAGE_SIZE);
+
+            List<MemberVo> members = memberProductMapper.selectMemberWithProducts(params);
+
+            currentPage++;
+
+            if (members.isEmpty() || members.size() < PAGE_SIZE) {
+                hasMoreData = false;
+            }
+
+
+            return members;
+
+        } catch (Exception e) {
+            log.error("배치 데이터 조회 실패 - 페이지: {}, targetDate: {}, error: {}",
+                    currentPage, targetDate, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    private String getFormattedTargetDate() {
+        if (targetDate != null && !targetDate.trim().isEmpty()&& !targetDate.equals("null")) {
+            try {
+                LocalDate.parse(targetDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                return targetDate;
+            } catch (Exception e) {
+                log.warn("targetDate 파싱 실패, 기본값 사용: {}", targetDate);
+                return getPreviousDay();
+            }
+        } else {
+            log.info("targetDate가 null이거나 비어있음, 어제 날짜 사용");
+
+            return getPreviousDay();
+        }
+    }
+
+    private String getPreviousDay() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        return yesterday.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+}

--- a/src/main/java/woojooin/planitbatch/batch/reader/totalInvestAmountReader/MonthlyInvestAmountReader.java
+++ b/src/main/java/woojooin/planitbatch/batch/reader/totalInvestAmountReader/MonthlyInvestAmountReader.java
@@ -1,0 +1,160 @@
+package woojooin.planitbatch.batch.reader.totalInvestAmountReader;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import woojooin.planitbatch.domain.mapper.totalInvestAmount.WeeklyReportMapper;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@StepScope
+@Slf4j
+public class MonthlyInvestAmountReader implements ItemReader<List<WeeklyInvestSummaryVo>> {
+
+    private final WeeklyReportMapper weeklyReportMapper;
+
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+
+    private static final int PAGE_SIZE = 1000; // 멤버 수
+    private int currentPage = 0;
+    private int currentIndex = 0;
+    private List<List<WeeklyInvestSummaryVo>> currentBatch; // 멤버별로 그룹핑된 리스트들
+    private boolean hasMoreData = true;
+
+    // 지난달 날짜 범위
+    private String lastMonthStartDate;
+    private String lastMonthEndDate;
+
+    public MonthlyInvestAmountReader(WeeklyReportMapper weeklyReportMapper) {
+        this.weeklyReportMapper = weeklyReportMapper;
+        log.info("MonthlyReportAmountReader 초기화 완료 - 지난달 주간 데이터 처리");
+    }
+
+    @Override
+    public List<WeeklyInvestSummaryVo> read() throws Exception {
+        if (lastMonthStartDate == null || lastMonthEndDate == null) {
+            calculateLastMonthRange();
+        }
+
+        if (currentBatch == null || currentIndex >= currentBatch.size()) {
+            if (!hasMoreData) {
+                log.info("더 이상 읽을 데이터가 없습니다. 총 {}페이지 처리 완료 (지난달: {} ~ {})",
+                        currentPage, lastMonthStartDate, lastMonthEndDate);
+                return null;
+            }
+
+            // 이전 배치 메모리 해제
+            if (currentBatch != null) {
+                currentBatch.clear();
+                currentBatch = null;
+            }
+
+            currentBatch = fetchNextBatch();
+            currentIndex = 0;
+
+            if (currentBatch == null || currentBatch.isEmpty()) {
+                log.info("배치 조회 완료 - 더 이상 데이터가 없습니다. (지난달: {} ~ {})", lastMonthStartDate, lastMonthEndDate);
+                hasMoreData = false;
+                return null;
+            }
+        }
+
+        List<WeeklyInvestSummaryVo> memberLastMonthWeeklyData = currentBatch.get(currentIndex++);
+
+        return memberLastMonthWeeklyData;
+    }
+
+    @Transactional(readOnly = true)
+    public List<List<WeeklyInvestSummaryVo>> fetchNextBatch() throws Exception {
+        List<List<WeeklyInvestSummaryVo>> groupedData = null;
+
+        try {
+            Map<String, Object> params = new HashMap<>();
+
+            params.put("startDate", lastMonthStartDate);
+            params.put("endDate", lastMonthEndDate);
+
+            int offset = currentPage * PAGE_SIZE;
+            params.put("_skiprows", offset);
+            params.put("_pagesize", PAGE_SIZE);
+
+            List<Long> memberIds = weeklyReportMapper.selectMemberIdsForMonth(params);
+
+            if (memberIds == null || memberIds.isEmpty()) {
+                return new ArrayList<>();
+            }
+
+            groupedData = new ArrayList<>();
+
+            for (Long memberId : memberIds) {
+                Map<String, Object> memberParams = new HashMap<>();
+                memberParams.put("memberId", memberId);
+                memberParams.put("startDate", lastMonthStartDate);
+                memberParams.put("endDate", lastMonthEndDate);
+
+                List<WeeklyInvestSummaryVo> memberMonthlyWeeklyData =
+                        weeklyReportMapper.selectMemberWeeklyDataForMonth(memberParams);
+
+                if (memberMonthlyWeeklyData != null && !memberMonthlyWeeklyData.isEmpty()) {
+                    groupedData.add(memberMonthlyWeeklyData);
+                    log.debug("멤버 {} 지난달 주간 데이터 {}건 조회", memberId, memberMonthlyWeeklyData.size());
+                }
+            }
+
+            currentPage++;
+
+            if (memberIds.size() < PAGE_SIZE) {
+                hasMoreData = false;
+            }
+
+            return groupedData;
+
+        } catch (Exception e) {
+            log.error("지난달 주간 그룹 데이터 조회 실패 - 페이지: {}, 지난달범위: {} ~ {}, error: {}",
+                    currentPage, lastMonthStartDate, lastMonthEndDate, e.getMessage(), e);
+            throw e;
+
+        } finally {
+            log.debug("지난달 주간 그룹 조회 완료 - 페이지: {}, 결과 크기: {}",
+                    currentPage - 1, groupedData != null ? groupedData.size() : 0);
+        }
+    }
+
+    private void calculateLastMonthRange() {
+        LocalDate baseDate;
+
+        // targetDate가 있으면 해당 날짜 기준, 없으면 현재 날짜 기준
+        if (targetDate != null && !targetDate.trim().isEmpty() && !targetDate.equals("null")) {
+            try {
+                baseDate = LocalDate.parse(targetDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                log.info("사용자 지정 기준 날짜: {}", baseDate);
+            } catch (Exception e) {
+                log.warn("targetDate 파싱 실패, 현재 날짜 사용: {}", targetDate);
+                baseDate = LocalDate.now();
+            }
+        } else {
+            baseDate = LocalDate.now();
+        }
+        LocalDate lastMonthStart = baseDate.minusMonths(1).with(TemporalAdjusters.firstDayOfMonth());
+        LocalDate lastMonthEnd = baseDate.minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+
+        lastMonthStartDate = lastMonthStart.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        lastMonthEndDate = lastMonthEnd.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        log.info("지난달 범위 계산 완료 - 기준날짜: {}, 지난달범위: {} ~ {} ({}년 {}월)",
+                baseDate, lastMonthStartDate, lastMonthEndDate,
+                lastMonthStart.getYear(), lastMonthStart.getMonthValue());
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/reader/totalInvestAmountReader/WeeklyInvestAmountReader.java
+++ b/src/main/java/woojooin/planitbatch/batch/reader/totalInvestAmountReader/WeeklyInvestAmountReader.java
@@ -1,0 +1,154 @@
+package woojooin.planitbatch.batch.reader.totalInvestAmountReader;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import woojooin.planitbatch.domain.mapper.totalInvestAmount.DailyReportMapper;
+import woojooin.planitbatch.domain.vo.DailyInvestSummaryVo;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@StepScope
+@Slf4j
+public class WeeklyInvestAmountReader implements ItemReader<List<DailyInvestSummaryVo>> {
+
+    private final DailyReportMapper dailyReportMapper;
+
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+
+    private static final int PAGE_SIZE = 1000;
+    private int currentPage = 0;
+    private int currentIndex = 0;
+    private List<List<DailyInvestSummaryVo>> currentBatch;
+    private boolean hasMoreData = true;
+    private String lastWeekStartDate;
+    private String lastWeekEndDate;
+
+    public WeeklyInvestAmountReader(DailyReportMapper dailyReportMapper) {
+        this.dailyReportMapper = dailyReportMapper;
+        log.info("WeeklyInvestAmountReader 초기화 완료 - 지난주 데이터 처리");
+    }
+
+    @Override
+    public List<DailyInvestSummaryVo> read() throws Exception {
+        if (lastWeekStartDate == null || lastWeekEndDate == null) {
+            calculateLastWeekRange();
+        }
+
+        if (currentBatch == null || currentIndex >= currentBatch.size()) {
+            if (!hasMoreData) {
+                return null;
+            }
+
+            // 이전 배치 메모리 해제
+            if (currentBatch != null) {
+                currentBatch.clear();
+                currentBatch = null;
+            }
+
+            currentBatch = fetchNextBatch();
+            currentIndex = 0;
+
+            if (currentBatch == null || currentBatch.isEmpty()) {
+                log.info("배치 조회 완료 - 더 이상 데이터가 없습니다. (지난주: {} ~ {})", lastWeekStartDate, lastWeekEndDate);
+                hasMoreData = false;
+                return null;
+            }
+        }
+
+        List<DailyInvestSummaryVo> memberLastWeekData = currentBatch.get(currentIndex++);
+
+        return memberLastWeekData;
+    }
+
+    @Transactional(readOnly = true)
+    public List<List<DailyInvestSummaryVo>> fetchNextBatch() throws Exception {
+        List<List<DailyInvestSummaryVo>> groupedData = null;
+
+        try {
+            Map<String, Object> params = new HashMap<>();
+
+            params.put("startDate", lastWeekStartDate);
+            params.put("endDate", lastWeekEndDate);
+
+            int offset = currentPage * PAGE_SIZE;
+            params.put("_skiprows", offset);
+            params.put("_pagesize", PAGE_SIZE);
+
+            List<Long> memberIds = dailyReportMapper.selectMemberIdsForWeek(params);
+
+            if (memberIds == null || memberIds.isEmpty()) {
+                log.info("조회된 멤버 ID가 없습니다 - 페이지: {}", currentPage);
+                return new ArrayList<>();
+            }
+
+            groupedData = new ArrayList<>();
+
+            for (Long memberId : memberIds) {
+                Map<String, Object> memberParams = new HashMap<>();
+                memberParams.put("memberId", memberId);
+                memberParams.put("startDate", lastWeekStartDate);
+                memberParams.put("endDate", lastWeekEndDate);
+
+                List<DailyInvestSummaryVo> memberWeeklyData =
+                        dailyReportMapper.selectMemberDailyDataForWeek(memberParams);
+
+                if (memberWeeklyData != null && !memberWeeklyData.isEmpty()) {
+                    groupedData.add(memberWeeklyData);
+                    log.debug("멤버 {} 지난주 데이터 {}건 조회", memberId, memberWeeklyData.size());
+                }
+            }
+
+            currentPage++;
+
+            if (memberIds.size() < PAGE_SIZE) {
+                hasMoreData = false;
+            }
+
+            return groupedData;
+
+        } catch (Exception e) {
+            log.error("지난주 그룹 데이터 조회 실패 - 페이지: {}, 지난주범위: {} ~ {}, error: {}",
+                    currentPage, lastWeekStartDate, lastWeekEndDate, e.getMessage(), e);
+            throw e;
+
+        } finally {
+            log.debug("지난주 그룹 조회 완료 - 페이지: {}, 결과 크기: {}",
+                    currentPage - 1, groupedData != null ? groupedData.size() : 0);
+        }
+    }
+
+    private void calculateLastWeekRange() {
+        LocalDate baseDate;
+
+        // targetDate가 있으면 해당 날짜 기준, 없으면 현재 날짜 기준
+        if (targetDate != null && !targetDate.trim().isEmpty() && !targetDate.equals("null")) {
+            try {
+                baseDate = LocalDate.parse(targetDate, DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                log.info("사용자 지정 기준 날짜: {}", baseDate);
+            } catch (Exception e) {
+                log.warn("targetDate 파싱 실패, 현재 날짜 사용: {}", targetDate);
+                baseDate = LocalDate.now();
+            }
+        } else {
+            baseDate = LocalDate.now();
+        }
+
+        LocalDate lastWeekStart = baseDate.minusWeeks(1).with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY));
+        LocalDate lastWeekEnd = lastWeekStart.plusDays(6); // 일요일
+
+        lastWeekStartDate = lastWeekStart.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        lastWeekEndDate = lastWeekEnd.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/DailyInvestAmountScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/DailyInvestAmountScheduler.java
@@ -1,0 +1,50 @@
+package woojooin.planitbatch.batch.scheduler.totalInvestAmountScheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyInvestAmountScheduler {
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    @Qualifier("dailyInvestJob")
+    private Job dailyInvestJob;
+
+
+    @Scheduled(cron = "0 44 15 * * ?")
+    public void runDailyInvestmentJob()
+    {
+        try {
+            log.info("일간 투자금액 계산 배치 작업 시작");
+
+            String targetDate = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                            .addString("targetDate", targetDate)
+                            .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+                    log.info("배치 작업 시작 - targetDate:{}", targetDate);
+            // Job 실행
+            jobLauncher.run(dailyInvestJob, jobParameters);
+
+            log.info("일간 투자금액 계산 배치 작업 완료");
+        } catch (Exception e) {
+            log.error("일간 투자금액  계산 배치 작업 실패", e);
+        }
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/DailyInvestAmountScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/DailyInvestAmountScheduler.java
@@ -26,6 +26,7 @@ public class DailyInvestAmountScheduler {
 
 
     @Scheduled(cron = "0 44 15 * * ?")
+//    @Scheduled(cron = "0 */2 * * * ?") // 테스트용, 2분마다 실행
     public void runDailyInvestmentJob()
     {
         try {

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/MonthlyInvestAmountScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/MonthlyInvestAmountScheduler.java
@@ -23,8 +23,9 @@ public class MonthlyInvestAmountScheduler {
     @Qualifier("monthlyInvestJob")
     private Job monthlyInvestJob;
 
-    @Scheduled(cron = "0 0 0 1 * ?")// 매월 1일 자정에 실행
-    public void runMonthlyInvestmentJob() {
+//    @Scheduled(cron = "0 0 0 1 * ?")// 매월 1일 자정에 실행
+@Scheduled(cron = "0 */2 * * * ?") // 테스트용, 2분마다 실행
+public void runMonthlyInvestmentJob() {
         try {
             log.info("월간 투자금액 계산 배치 작업 시작");
             String targetDate = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/MonthlyInvestAmountScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/MonthlyInvestAmountScheduler.java
@@ -1,0 +1,47 @@
+package woojooin.planitbatch.batch.scheduler.totalInvestAmountScheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+public class MonthlyInvestAmountScheduler {
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    @Qualifier("monthlyInvestJob")
+    private Job monthlyInvestJob;
+
+    @Scheduled(cron = "0 0 0 1 * ?")// 매월 1일 자정에 실행
+    public void runMonthlyInvestmentJob() {
+        try {
+            log.info("월간 투자금액 계산 배치 작업 시작");
+            String targetDate = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("targetDate", targetDate)
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+            log.info("배치 작업 시작 - targetDate: {}", targetDate);
+
+            // Job 실행
+            jobLauncher.run(monthlyInvestJob, jobParameters);
+
+            log.info("월간 투자금액 계산 배치 작업 완료");
+        } catch (Exception e) {
+            log.error("월간 투자금액 계산 배치 작업 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/WeeklyInvestAmountScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/WeeklyInvestAmountScheduler.java
@@ -1,0 +1,47 @@
+package woojooin.planitbatch.batch.scheduler.totalInvestAmountScheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Component
+public class WeeklyInvestAmountScheduler {
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    @Qualifier("weeklyInvestJob")
+    private Job weeklyInvestJob;
+
+    @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 자정에 실행
+    public  void runWeeklyInvestmentJob() {
+        try {
+            log.info("주간 투자금액 계산 배치 작업 시작");
+            String targetDate = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("targetDate", targetDate)
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+            log.info("배치 작업 시작 - targetDate: {}", targetDate);
+
+            // Job 실행
+            jobLauncher.run(weeklyInvestJob, jobParameters);
+
+            log.info("주간 투자금액 계산 배치 작업 완료");
+        } catch (Exception e) {
+            log.error("주간 투자금액 계산 배치 작업 실패", e);
+        }
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/WeeklyInvestAmountScheduler.java
+++ b/src/main/java/woojooin/planitbatch/batch/scheduler/totalInvestAmountScheduler/WeeklyInvestAmountScheduler.java
@@ -24,7 +24,8 @@ public class WeeklyInvestAmountScheduler {
     private Job weeklyInvestJob;
 
     @Scheduled(cron = "0 0 0 * * MON") // 매주 월요일 자정에 실행
-    public  void runWeeklyInvestmentJob() {
+//        @Scheduled(cron = "0 */2 * * * ?") // 테스트용, 2분마다 실행
+    public void runWeeklyInvestmentJob() {
         try {
             log.info("주간 투자금액 계산 배치 작업 시작");
             String targetDate = LocalDate.now().minusDays(1).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));

--- a/src/main/java/woojooin/planitbatch/batch/writer/totalInvestAmountWriter/DailyInvestAmountWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/totalInvestAmountWriter/DailyInvestAmountWriter.java
@@ -1,0 +1,35 @@
+package woojooin.planitbatch.batch.writer.totalInvestAmountWriter;
+
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import woojooin.planitbatch.domain.mapper.totalInvestAmount.DailyInvestSummaryMapper;
+import woojooin.planitbatch.domain.vo.DailyInvestSummaryVo;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Component
+public class DailyInvestAmountWriter implements ItemWriter<DailyInvestSummaryVo> {
+    @Autowired
+    private DailyInvestSummaryMapper dailyInvestSummaryMapper;
+
+    @Override
+    @Transactional
+    public void write(List<? extends DailyInvestSummaryVo> items) throws Exception {
+
+            try {
+                for (DailyInvestSummaryVo item : items) {
+                    if (item == null || item.getMemberId() == null) continue;
+                    item.setUpdatedAt(new Date());
+                    dailyInvestSummaryMapper.insert(item);
+                }
+            } catch (Exception e) {
+                // rollback 원인 확인
+                System.err.println("Writer 예외 발생: " + e.getMessage());
+                throw e;
+            }
+        }
+    }

--- a/src/main/java/woojooin/planitbatch/batch/writer/totalInvestAmountWriter/MonthlyInvestAmountWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/totalInvestAmountWriter/MonthlyInvestAmountWriter.java
@@ -1,0 +1,63 @@
+package woojooin.planitbatch.batch.writer.totalInvestAmountWriter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import woojooin.planitbatch.domain.mapper.totalInvestAmount.MonthlyInvestSummaryMapper;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MonthlyInvestSummaryVo;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Component
+@Slf4j
+public class MonthlyInvestAmountWriter implements ItemWriter<MonthlyInvestSummaryVo> {
+    @Autowired
+    private MonthlyInvestSummaryMapper monthlyInvestSummaryMapper;
+
+    @Override
+    @Transactional
+    public void write(List<? extends MonthlyInvestSummaryVo> list) throws Exception {
+        if (list == null || list.isEmpty()) {
+            return;
+        }
+
+        int successCount = 0;
+        int skipCount = 0;
+        Timestamp currentTime = new Timestamp(System.currentTimeMillis());
+
+        try {
+            for (MonthlyInvestSummaryVo item : list) {
+                if (item == null || item.getMemberId() == null) {
+                    skipCount++;
+                    continue;
+                }
+
+                if (item.getUpdatedAt() == null) {
+                    item.setUpdatedAt(currentTime);
+                }
+                if (item.getCreatedAt() == null) {
+                    item.setCreatedAt(currentTime);
+                }
+                if (item.getIsDeleted() == null) {
+                    item.setIsDeleted(false);
+                }
+
+                // monthly_report 테이블에 INSERT
+                monthlyInvestSummaryMapper.insert(item);
+                successCount++;
+            }
+
+
+        } catch (Exception e) {
+            log.error("주간 투자 집계 Writer 예외 발생 - 성공: {}건, 스킵: {}건, 오류: {}",
+                    successCount, skipCount, e.getMessage(), e);
+
+            // rollback 원인 확인
+            System.err.println("WeeklyWriter 예외 발생: " + e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/woojooin/planitbatch/batch/writer/totalInvestAmountWriter/WeeklyInvestAmountWriter.java
+++ b/src/main/java/woojooin/planitbatch/batch/writer/totalInvestAmountWriter/WeeklyInvestAmountWriter.java
@@ -1,0 +1,65 @@
+package woojooin.planitbatch.batch.writer.totalInvestAmountWriter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import woojooin.planitbatch.domain.mapper.totalInvestAmount.WeeklyInvestSummaryMapper;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Component
+@Slf4j
+public class WeeklyInvestAmountWriter implements ItemWriter<WeeklyInvestSummaryVo> {
+
+    @Autowired
+    private WeeklyInvestSummaryMapper weeklyInvestSummaryMapper;
+
+    @Override
+    @Transactional
+    public void write(List<? extends WeeklyInvestSummaryVo> items) throws Exception {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+
+        int successCount = 0;
+        int skipCount = 0;
+        Timestamp currentTime = new Timestamp(System.currentTimeMillis());
+
+        try {
+            for (WeeklyInvestSummaryVo item : items) {
+                if (item == null || item.getMemberId() == null) {
+                    skipCount++;
+                    continue;
+                }
+
+                if (item.getUpdatedAt() == null) {
+                    item.setUpdatedAt(currentTime);
+                }
+                if (item.getCreatedAt() == null) {
+                    item.setCreatedAt(currentTime);
+                }
+                if (item.getIsDeleted() == null) {
+                    item.setIsDeleted(false);
+                }
+
+                // weekly_report 테이블에 INSERT
+                weeklyInvestSummaryMapper.insert(item);
+                successCount++;
+            }
+
+            log.info("주간 투자 집계 Writer 처리 완료 - 성공: {}건, 스킵: {}건", successCount, skipCount);
+
+        } catch (Exception e) {
+            log.error("주간 투자 집계 Writer 예외 발생 - 성공: {}건, 스킵: {}건, 오류: {}",
+                    successCount, skipCount, e.getMessage(), e);
+
+            // rollback 원인 확인
+            System.err.println("WeeklyWriter 예외 발생: " + e.getMessage());
+            throw e; // 예외 다시 던져서 Spring Batch가 인지하게
+        }
+    }
+}

--- a/src/main/java/woojooin/planitbatch/domain/mapper/MemberProductMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/MemberProductMapper.java
@@ -1,14 +1,18 @@
 package woojooin.planitbatch.domain.mapper;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import woojooin.planitbatch.domain.vo.MemberProduct;
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MemberVo;
 
 @Mapper
 public interface MemberProductMapper {
     List<MemberProduct> getMemberProductsByMemberIds(@Param("memberIds") List<Long> memberIds);
     List<MemberProduct> getMemberProductsByIds(@Param("memberProductIds") List<Long> memberProductIds);
+    List<MemberVo> selectMemberWithProducts(Map<String, Object> params);
+
 }

--- a/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/DailyInvestSummaryMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/DailyInvestSummaryMapper.java
@@ -1,0 +1,13 @@
+package woojooin.planitbatch.domain.mapper.totalInvestAmount;
+
+import org.apache.ibatis.annotations.Param;
+import woojooin.planitbatch.domain.vo.DailyInvestSummaryVo;
+
+import java.util.Date;
+import java.util.List;
+
+public interface DailyInvestSummaryMapper {
+    int insert(DailyInvestSummaryVo dailyInvestSummaryVo);
+
+    int batchInsert(@Param("dailyInvestSummaryList") List<DailyInvestSummaryVo> dailyInvestSummaryList);
+}

--- a/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/DailyReportMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/DailyReportMapper.java
@@ -1,0 +1,13 @@
+package woojooin.planitbatch.domain.mapper.totalInvestAmount;
+
+import woojooin.planitbatch.domain.vo.DailyInvestSummaryVo;
+
+import java.util.List;
+import java.util.Map;
+
+public interface DailyReportMapper {
+    List<DailyInvestSummaryVo> selectDailyDataForWeek(Map<String, Object> params);
+    List<Long> selectMemberIdsForWeek(Map<String, Object> params);
+    List<DailyInvestSummaryVo> selectMemberDailyDataForWeek(Map<String, Object> params);
+
+}

--- a/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/MonthlyInvestSummaryMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/MonthlyInvestSummaryMapper.java
@@ -1,0 +1,7 @@
+package woojooin.planitbatch.domain.mapper.totalInvestAmount;
+
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.MonthlyInvestSummaryVo;
+
+public interface MonthlyInvestSummaryMapper {
+    void insert(MonthlyInvestSummaryVo monthlyInvestSummaryVo);
+}

--- a/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/WeeklyInvestSummaryMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/WeeklyInvestSummaryMapper.java
@@ -1,0 +1,8 @@
+package woojooin.planitbatch.domain.mapper.totalInvestAmount;
+
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo;
+
+public interface WeeklyInvestSummaryMapper {
+    void insert(WeeklyInvestSummaryVo weeklyInvestSummaryVo);
+
+}

--- a/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/WeeklyReportMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/mapper/totalInvestAmount/WeeklyReportMapper.java
@@ -1,0 +1,12 @@
+package woojooin.planitbatch.domain.mapper.totalInvestAmount;
+
+import woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo;
+
+import java.util.List;
+import java.util.Map;
+
+public interface WeeklyReportMapper {
+    List<WeeklyInvestSummaryVo> selectWeeklyDataForMonth(Map<String, Object> params);
+    List<Long> selectMemberIdsForMonth(Map<String, Object> params);
+    List<WeeklyInvestSummaryVo> selectMemberWeeklyDataForMonth(Map<String, Object> params);
+}

--- a/src/main/java/woojooin/planitbatch/domain/product/mapper/ProductMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/product/mapper/ProductMapper.java
@@ -22,7 +22,6 @@ public interface ProductMapper {
 
 	List<Product> findAll();
 
-<<<<<<< HEAD
 	@MapKey("shortenCode")
 	Map<String, Product> getProductsByShortenCodes(@Param("productIds") List<String> productIds);
 
@@ -32,8 +31,6 @@ public interface ProductMapper {
 		@Param("limit") int limit);
 
 	int countAll();
-=======
 	@MapKey("productId")
 	Map<String, Product> getProductsByIds(@Param("productIds") List<String> productIds);
->>>>>>> ef6542d (feat: 배치에 평가금액 추가)
 }

--- a/src/main/java/woojooin/planitbatch/domain/product/mapper/ProductMapper.java
+++ b/src/main/java/woojooin/planitbatch/domain/product/mapper/ProductMapper.java
@@ -22,6 +22,7 @@ public interface ProductMapper {
 
 	List<Product> findAll();
 
+<<<<<<< HEAD
 	@MapKey("shortenCode")
 	Map<String, Product> getProductsByShortenCodes(@Param("productIds") List<String> productIds);
 
@@ -31,4 +32,8 @@ public interface ProductMapper {
 		@Param("limit") int limit);
 
 	int countAll();
+=======
+	@MapKey("productId")
+	Map<String, Product> getProductsByIds(@Param("productIds") List<String> productIds);
+>>>>>>> ef6542d (feat: 배치에 평가금액 추가)
 }

--- a/src/main/java/woojooin/planitbatch/domain/vo/DailyInvestSummaryVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/DailyInvestSummaryVo.java
@@ -13,6 +13,7 @@ import java.util.Date;
 public class DailyInvestSummaryVo {
     private Long memberId;
     private BigDecimal dailyTotal;
+    private BigDecimal dailyValuationTotal;
     private int dailyCount;
     private Date updatedAt;
     private Date createdAt;

--- a/src/main/java/woojooin/planitbatch/domain/vo/DailyInvestSummaryVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/DailyInvestSummaryVo.java
@@ -1,0 +1,20 @@
+package woojooin.planitbatch.domain.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyInvestSummaryVo {
+    private Long memberId;
+    private BigDecimal dailyTotal;
+    private int dailyCount;
+    private Date updatedAt;
+    private Date createdAt;
+    private int isDeleted;
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/MemberProduct.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/MemberProduct.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 public class MemberProduct {
     private Long memberProductId;
     private Long memberId;
+    private String productId;
     private String shortenCode;
     private Double presentAmount;
     private Long quantity;

--- a/src/main/java/woojooin/planitbatch/domain/vo/Product.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/Product.java
@@ -7,6 +7,9 @@ import lombok.Data;
 
 @Data
 public class Product {
+
+	private String productId;
+
 	/** 상품코드 */
 	private String productIdentifier;
 

--- a/src/main/java/woojooin/planitbatch/domain/vo/Product.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/Product.java
@@ -1,0 +1,57 @@
+package woojooin.planitbatch.domain.vo;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class Product {
+	/** 상품코드 */
+	private String productIdentifier;
+
+	/** 단축코드 */
+	private String shortCode;
+
+	/** 국제증권식별번호 코드 */
+	private String internationalSecuritiesIdentificationNumberCode;
+
+	/** 상품명 */
+	private String productName;
+
+	/** 기준일자 */
+	private LocalDate baseDate;
+
+	/** 종가 */
+	private BigDecimal closingPrice;
+
+	/** 전일 대비 (가격 변화) */
+	private BigDecimal priceChangeFromPreviousDay;
+
+	/** 등락률 (%) */
+	private BigDecimal fluctuationRate;
+
+	/** 시가 (시작가) */
+	private BigDecimal openingPrice;
+
+	/** 고가 */
+	private BigDecimal highPrice;
+
+	/** 저가 */
+	private BigDecimal lowPrice;
+
+	/** 거래량 */
+	private Long tradingVolume;
+
+	/** 거래대금 */
+	private Long transactionAmount;
+
+	/** 상장주식수 */
+	private Long numberOfListedShares;
+
+	/** 시가총액 */
+	private BigDecimal marketCapitalization;
+
+	/** 투자유형 */
+	private String investmentType;
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/MemberProductVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/MemberProductVo.java
@@ -1,0 +1,21 @@
+package woojooin.planitbatch.domain.vo.totalInvestAmountVo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberProductVo {
+    private Long memberId;
+    private String productId;
+    private BigDecimal valuationAmount;
+    private BigDecimal quantity;
+    private BigDecimal purchaseAmount;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/MemberVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/MemberVo.java
@@ -1,0 +1,16 @@
+package woojooin.planitbatch.domain.vo.totalInvestAmountVo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberVo {
+    private Long memberId;
+    private List<MemberProductVo> products;
+
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/MonthlyInvestSummaryVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/MonthlyInvestSummaryVo.java
@@ -13,6 +13,7 @@ import java.sql.Timestamp;
 public class MonthlyInvestSummaryVo {
     private Long memberId;
     private BigDecimal monthlyTotalAmount;
+    private BigDecimal monthlyValuationTotal;
     private int monthlyTotalCount;
     private Timestamp updatedAt;
     private Timestamp createdAt;

--- a/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/MonthlyInvestSummaryVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/MonthlyInvestSummaryVo.java
@@ -1,0 +1,20 @@
+package woojooin.planitbatch.domain.vo.totalInvestAmountVo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MonthlyInvestSummaryVo {
+    private Long memberId;
+    private BigDecimal monthlyTotalAmount;
+    private int monthlyTotalCount;
+    private Timestamp updatedAt;
+    private Timestamp createdAt;
+    private Boolean isDeleted;
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/WeeklyInvestSummaryVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/WeeklyInvestSummaryVo.java
@@ -1,0 +1,20 @@
+package woojooin.planitbatch.domain.vo.totalInvestAmountVo;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeeklyInvestSummaryVo {
+    private Long memberId;
+    private BigDecimal weeklyTotalAmount;
+    private Integer weeklyTotalCount;
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+    private Boolean isDeleted;
+}

--- a/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/WeeklyInvestSummaryVo.java
+++ b/src/main/java/woojooin/planitbatch/domain/vo/totalInvestAmountVo/WeeklyInvestSummaryVo.java
@@ -13,6 +13,7 @@ import java.sql.Timestamp;
 public class WeeklyInvestSummaryVo {
     private Long memberId;
     private BigDecimal weeklyTotalAmount;
+    private BigDecimal weeklyValuationTotal;
     private Integer weeklyTotalCount;
     private Timestamp createdAt;
     private Timestamp updatedAt;

--- a/src/main/java/woojooin/planitbatch/global/config/DatabaseConfig.java
+++ b/src/main/java/woojooin/planitbatch/global/config/DatabaseConfig.java
@@ -121,14 +121,14 @@ public class DatabaseConfig implements BatchConfigurer {
 		return new DataSourceTransactionManager(batchDataSource());
 	}
 
-	@Override
-	public JobRepository getJobRepository() throws Exception {
-		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
-		factory.setDataSource(batchDataSource());
-		factory.setTransactionManager(batchTransactionManager());
-		factory.afterPropertiesSet();
-		return factory.getObject();
-	}
+    @Override
+    public JobRepository getJobRepository() throws Exception {
+        JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
+        factory.setDataSource(batchDataSource());
+        factory.setTransactionManager(batchTransactionManager());
+        factory.afterPropertiesSet();
+        return factory.getObject();
+    }
 
 	@Override
 	public PlatformTransactionManager getTransactionManager() throws Exception {

--- a/src/main/java/woojooin/planitbatch/global/config/DatabaseConfig.java
+++ b/src/main/java/woojooin/planitbatch/global/config/DatabaseConfig.java
@@ -102,7 +102,7 @@ public class DatabaseConfig implements BatchConfigurer {
 
 		sessionFactory.setDataSource(dataSource());
 
-		sessionFactory.setConfigLocation(new ClassPathResource("mybatis-config.xml"));
+        sessionFactory.setConfigLocation(new ClassPathResource("mybatis-config.xml"));
 		sessionFactory.setMapperLocations(
 			new PathMatchingResourcePatternResolver()
 				.getResources("classpath:mapper/*.xml")
@@ -121,14 +121,14 @@ public class DatabaseConfig implements BatchConfigurer {
 		return new DataSourceTransactionManager(batchDataSource());
 	}
 
-    @Override
-    public JobRepository getJobRepository() throws Exception {
-        JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
-        factory.setDataSource(batchDataSource());
-        factory.setTransactionManager(batchTransactionManager());
-        factory.afterPropertiesSet();
-        return factory.getObject();
-    }
+	@Override
+	public JobRepository getJobRepository() throws Exception {
+		JobRepositoryFactoryBean factory = new JobRepositoryFactoryBean();
+		factory.setDataSource(batchDataSource());
+		factory.setTransactionManager(batchTransactionManager());
+		factory.afterPropertiesSet();
+		return factory.getObject();
+	}
 
 	@Override
 	public PlatformTransactionManager getTransactionManager() throws Exception {

--- a/src/main/resources/batch-config.xml
+++ b/src/main/resources/batch-config.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:batch="http://www.springframework.org/schema/batch"
+       xsi:schemaLocation="
+           http://www.springframework.org/schema/beans
+           http://www.springframework.org/schema/beans/spring-beans.xsd
+           http://www.springframework.org/schema/batch
+           http://www.springframework.org/schema/batch/spring-batch.xsd">
+
+    <!-- Job Repository -->
+    <bean id="jobRepository"
+          class="org.springframework.batch.core.repository.support.MapJobRepositoryFactoryBean">
+        <property name="transactionManager" ref="transactionManager"/>
+    </bean>
+
+    <!-- Job Launcher -->
+    <bean id="jobLauncher"
+          class="org.springframework.batch.core.launch.support.SimpleJobLauncher">
+        <property name="jobRepository" ref="jobRepository"/>
+    </bean>
+
+    <!-- Transaction Manager -->
+    <bean id="transactionManager"
+          class="org.springframework.batch.support.transaction.ResourcelessTransactionManager"/>
+
+</beans>

--- a/src/main/resources/mapper/DailyInvestSummaryMapper.xml
+++ b/src/main/resources/mapper/DailyInvestSummaryMapper.xml
@@ -7,6 +7,7 @@
         INSERT INTO daily_report (
         member_id,
         daily_invest_total,
+        daily_valuation_total,
         daily_invest_count,
         updated_at,
         is_deleted,
@@ -14,6 +15,7 @@
         ) VALUES (
         #{memberId},
         #{dailyTotal},
+        #{dailyValuationTotal},
         #{dailyCount},
         <choose>
             <when test="updatedAt != null">

--- a/src/main/resources/mapper/DailyInvestSummaryMapper.xml
+++ b/src/main/resources/mapper/DailyInvestSummaryMapper.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="woojooin.planitbatch.domain.mapper.totalInvestAmount.DailyInvestSummaryMapper">
+
+    <insert id="insert" parameterType="woojooin.planitbatch.domain.vo.DailyInvestSummaryVo">
+        INSERT INTO daily_report (
+        member_id,
+        daily_invest_total,
+        daily_invest_count,
+        updated_at,
+        is_deleted,
+        created_at
+        ) VALUES (
+        #{memberId},
+        #{dailyTotal},
+        #{dailyCount},
+        <choose>
+            <when test="updatedAt != null">
+                #{updatedAt}
+            </when>
+            <otherwise>
+                CURRENT_TIMESTAMP
+            </otherwise>
+        </choose>,
+        #{isDeleted},
+        <choose>
+            <when test="createdAt != null">
+                #{createdAt}
+            </when>
+            <otherwise>
+                CURRENT_TIMESTAMP
+            </otherwise>
+        </choose>
+        )
+    </insert>
+
+    <insert id="batchInsert">
+        INSERT INTO daily_report (
+        member_id,
+        daily_invest_total,
+        daily_invest_count,
+        updated_at,
+        is_deleted,
+        created_at
+        ) VALUES
+        <foreach collection="collection" item="item" separator=",">
+            (
+            #{item.memberId},
+            #{item.dailyTotal},
+            #{item.dailyCount},
+            #{item.updatedAt},
+            #{item.isDeleted},
+            #{item.createdAt}
+            )
+        </foreach>
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/DailyReportMapper.xml
+++ b/src/main/resources/mapper/DailyReportMapper.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="woojooin.planitbatch.domain.mapper.totalInvestAmount.DailyReportMapper">
+
+    <resultMap id="DailyInvestSummaryVoResultMap" type="woojooin.planitbatch.domain.vo.DailyInvestSummaryVo">
+        <result property="memberId" column="member_id"/>
+        <result property="dailyTotal" column="daily_invest_total"/>
+        <result property="dailyCount" column="daily_invest_count"/>
+        <result property="updatedAt" column="updated_at"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="isDeleted" column="is_deleted"/>
+    </resultMap>
+
+    <!-- 지난주 전체 데이터 조회 (플랫 리스트) -->
+    <select id="selectDailyDataForWeek" resultMap="DailyInvestSummaryVoResultMap">
+        SELECT
+            member_id,
+            daily_invest_total,
+            daily_invest_count,
+            updated_at,
+            created_at,
+            is_deleted
+        FROM daily_report
+        WHERE DATE(updated_at) BETWEEN #{startDate} AND #{endDate}
+          AND is_deleted = 0
+          AND member_id IS NOT NULL
+          AND daily_invest_total > 0
+        ORDER BY member_id, updated_at
+    </select>
+
+    <!-- 지난주 데이터가 있는 멤버 ID 리스트 조회 (페이징) -->
+    <select id="selectMemberIdsForWeek" resultType="Long">
+        SELECT DISTINCT member_id
+        FROM daily_report
+        WHERE DATE(updated_at) BETWEEN #{startDate} AND #{endDate}
+          AND is_deleted = 0
+          AND member_id IS NOT NULL
+          AND daily_invest_total > 0
+        ORDER BY member_id
+            LIMIT #{_pagesize} OFFSET #{_skiprows}
+    </select>
+
+    <!-- 특정 멤버의 지난주 데이터 조회 -->
+    <select id="selectMemberDailyDataForWeek" resultMap="DailyInvestSummaryVoResultMap">
+        SELECT
+            member_id,
+            daily_invest_total,
+            daily_invest_count,
+            updated_at,
+            created_at,
+            is_deleted
+        FROM daily_report
+        WHERE member_id = #{memberId}
+          AND DATE(updated_at) BETWEEN #{startDate} AND #{endDate}
+          AND is_deleted = 0
+          AND daily_invest_total > 0
+        ORDER BY updated_at
+    </select>
+
+    <!-- 지난주 데이터가 있는 멤버 수 조회 -->
+    <select id="countMembersWithDataForWeek" resultType="int">
+        SELECT COUNT(DISTINCT member_id)
+        FROM daily_report
+        WHERE DATE(updated_at) BETWEEN #{startDate} AND #{endDate}
+          AND is_deleted = 0
+          AND member_id IS NOT NULL
+          AND daily_invest_total > 0
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/DailyReportMapper.xml
+++ b/src/main/resources/mapper/DailyReportMapper.xml
@@ -7,6 +7,7 @@
         <result property="memberId" column="member_id"/>
         <result property="dailyTotal" column="daily_invest_total"/>
         <result property="dailyCount" column="daily_invest_count"/>
+        <result property="dailyValuationTotal" column="daily_valuation_total"/>
         <result property="updatedAt" column="updated_at"/>
         <result property="createdAt" column="created_at"/>
         <result property="isDeleted" column="is_deleted"/>
@@ -18,6 +19,7 @@
             member_id,
             daily_invest_total,
             daily_invest_count,
+            daily_valuation_total,
             updated_at,
             created_at,
             is_deleted
@@ -47,6 +49,7 @@
             member_id,
             daily_invest_total,
             daily_invest_count,
+            daily_valuation_total,
             updated_at,
             created_at,
             is_deleted

--- a/src/main/resources/mapper/MemberProductMapper.xml
+++ b/src/main/resources/mapper/MemberProductMapper.xml
@@ -7,7 +7,8 @@
         SELECT
             member_product_id as memberProductId,
             member_id as memberId,
-            product_id as shortenCode,
+        product_id as productId,
+        product_id as shortenCode,
             present_amount as presentAmount,
             quantity
         FROM member_product
@@ -55,9 +56,9 @@
             AND mp.quantity > 0
         ORDER BY m.member_id, mp.updated_at
     </select>
-    
+
     <select id="getMemberProductsByIds" resultType="woojooin.planitbatch.domain.vo.MemberProduct">
-        SELECT 
+        SELECT
             member_product_id as memberProductId,
             member_id as memberId,
             product_id as productId,
@@ -69,5 +70,5 @@
             #{memberProductId}
         </foreach>
     </select>
-    
+
 </mapper>

--- a/src/main/resources/mapper/MemberProductMapper.xml
+++ b/src/main/resources/mapper/MemberProductMapper.xml
@@ -1,20 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="woojooin.planitbatch.domain.mapper.MemberProductMapper">
-    
-    
+
+
     <select id="getMemberProductsByMemberIds" resultType="woojooin.planitbatch.domain.vo.MemberProduct">
-        SELECT 
+        SELECT
             member_product_id as memberProductId,
             member_id as memberId,
             product_id as shortenCode,
             present_amount as presentAmount,
             quantity
         FROM member_product
-        WHERE member_id IN 
+        WHERE member_id IN
         <foreach collection="memberIds" item="memberId" open="(" close=")" separator=",">
             #{memberId}
         </foreach>
+    </select>
+
+
+    <!-- MemberVo ResultMap -->
+    <resultMap id="MemberVoResultMap" type="woojooin.planitbatch.domain.vo.totalInvestAmountVo.MemberVo">
+        <id property="memberId" column="member_id"/>
+        <collection property="products" ofType="woojooin.planitbatch.domain.vo.totalInvestAmountVo.MemberProductVo">
+            <result property="memberId" column="member_id"/>
+            <result property="productId" column="product_id"/>
+            <result property="createdAt" column="created_at"/>
+            <result property="valuationAmount" column="valuation_amount"/>
+            <result property="quantity" column="quantity"/>
+            <result property="purchaseAmount" column="purchase_amount"/>
+            <result property="updatedAt" column="updated_at"/>
+        </collection>
+    </resultMap>
+
+    <!-- 멤버별 상품 정보 조회 -->
+    <select id="selectMemberWithProducts" resultMap="MemberVoResultMap">
+        SELECT
+            m.member_id,
+            mp.product_id,
+            mp.valuation_amount,
+            mp.quantity,
+            mp.purchase_amount,
+            mp.created_at,
+            mp.updated_at
+        FROM (
+            SELECT member_id
+            FROM member
+            ORDER BY member_id
+                LIMIT #{_skiprows}, #{_pagesize}
+        ) m
+                 Right Join member_product mp
+                           ON m.member_id = mp.member_id
+            AND mp.updated_at IS NOT NULL
+            AND mp.purchase_amount > 0
+            AND mp.quantity > 0
+        ORDER BY m.member_id, mp.updated_at
     </select>
     
     <select id="getMemberProductsByIds" resultType="woojooin.planitbatch.domain.vo.MemberProduct">

--- a/src/main/resources/mapper/MemberProductMapper.xml
+++ b/src/main/resources/mapper/MemberProductMapper.xml
@@ -18,6 +18,20 @@
         </foreach>
     </select>
 
+    <select id="getMemberProductsByIds" resultType="woojooin.planitbatch.domain.vo.MemberProduct">
+        SELECT
+            member_product_id as memberProductId,
+            member_id as memberId,
+            product_id as productId,
+            present_amount as presentAmount,
+            quantity
+        FROM member_product
+        WHERE member_product_id IN
+        <foreach collection="memberProductIds" item="memberProductId" open="(" separator="," close=")">
+            #{memberProductId}
+        </foreach>
+    </select>
+
 
     <!-- MemberVo ResultMap -->
     <resultMap id="MemberVoResultMap" type="woojooin.planitbatch.domain.vo.totalInvestAmountVo.MemberVo">
@@ -55,20 +69,6 @@
             AND mp.purchase_amount > 0
             AND mp.quantity > 0
         ORDER BY m.member_id, mp.updated_at
-    </select>
-
-    <select id="getMemberProductsByIds" resultType="woojooin.planitbatch.domain.vo.MemberProduct">
-        SELECT
-            member_product_id as memberProductId,
-            member_id as memberId,
-            product_id as productId,
-            present_amount as presentAmount,
-            quantity
-        FROM member_product
-        WHERE member_product_id IN
-        <foreach collection="memberProductIds" item="memberProductId" open="(" separator="," close=")">
-            #{memberProductId}
-        </foreach>
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/MonthlyInvestSummaryMapper.xml
+++ b/src/main/resources/mapper/MonthlyInvestSummaryMapper.xml
@@ -7,6 +7,7 @@
     <resultMap id="MonthlyInvestSummaryVoResultMap" type="woojooin.planitbatch.domain.vo.totalInvestAmountVo.MonthlyInvestSummaryVo">
         <result property="memberId" column="member_id"/>
         <result property="monthlyTotalAmount" column="monthly_total_amount"/>
+        <result property="monthlyValuationTotal" column="monthly_valuation_total"/>
         <result property="monthlyTotalCount" column="monthly_total_count"/>
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
@@ -18,6 +19,7 @@
         INSERT INTO monthly_report (
         member_id,
         monthly_total_amount,
+        monthly_valuation_total,
         monthly_total_count,
         created_at,
         updated_at,
@@ -25,6 +27,7 @@
         ) VALUES (
         #{memberId},
         #{monthlyTotalAmount},
+        #{monthlyValuationTotal},
         #{monthlyTotalCount},
         <choose>
             <when test="createdAt != null">

--- a/src/main/resources/mapper/MonthlyInvestSummaryMapper.xml
+++ b/src/main/resources/mapper/MonthlyInvestSummaryMapper.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="woojooin.planitbatch.domain.mapper.totalInvestAmount.MonthlyInvestSummaryMapper">
+
+    <!-- MonthlyInvestSummaryVo ResultMap -->
+    <resultMap id="MonthlyInvestSummaryVoResultMap" type="woojooin.planitbatch.domain.vo.totalInvestAmountVo.MonthlyInvestSummaryVo">
+        <result property="memberId" column="member_id"/>
+        <result property="monthlyTotalAmount" column="monthly_total_amount"/>
+        <result property="monthlyTotalCount" column="monthly_total_count"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+        <result property="isDeleted" column="is_deleted"/>
+    </resultMap>
+
+    <!-- 월간 투자 집계 데이터 INSERT -->
+    <insert id="insert" parameterType="woojooin.planitbatch.domain.vo.totalInvestAmountVo.MonthlyInvestSummaryVo">
+        INSERT INTO monthly_report (
+        member_id,
+        monthly_total_amount,
+        monthly_total_count,
+        created_at,
+        updated_at,
+        is_deleted
+        ) VALUES (
+        #{memberId},
+        #{monthlyTotalAmount},
+        #{monthlyTotalCount},
+        <choose>
+            <when test="createdAt != null">
+                #{createdAt}
+            </when>
+            <otherwise>
+                CURRENT_TIMESTAMP
+            </otherwise>
+        </choose>,
+        <choose>
+            <when test="updatedAt != null">
+                #{updatedAt}
+            </when>
+            <otherwise>
+                CURRENT_TIMESTAMP
+            </otherwise>
+        </choose>,
+        #{isDeleted}
+        )
+    </insert>
+
+    <!-- Batch INSERT (성능 최적화용) -->
+    <insert id="batchInsert">
+        INSERT INTO monthly_report (
+        member_id,
+        monthly_total_amount,
+        monthly_total_count,
+        created_at,
+        updated_at,
+        is_deleted
+        ) VALUES
+        <foreach collection="collection" item="item" separator=",">
+            (
+            #{item.memberId},
+            #{item.monthlyTotalAmount},
+            #{item.monthlyTotalCount},
+            #{item.createdAt},
+            #{item.updatedAt},
+            #{item.isDeleted}
+            )
+        </foreach>
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/WeeklyInvestSummaryMapper.xml
+++ b/src/main/resources/mapper/WeeklyInvestSummaryMapper.xml
@@ -7,6 +7,7 @@
     <resultMap id="WeeklyInvestSummaryVoResultMap" type="woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo">
         <result property="memberId" column="member_id"/>
         <result property="weeklyTotalAmount" column="weekly_total_amount"/>
+        <result property="weeklyValuationTotal" column="weekly_valuation_total"/>
         <result property="weeklyTotalCount" column="weekly_total_count"/>
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
@@ -18,6 +19,7 @@
         INSERT INTO weekly_report (
         member_id,
         weekly_total_amount,
+        weekly_valuation_total,
         weekly_total_count,
         created_at,
         updated_at,
@@ -25,6 +27,7 @@
         ) VALUES (
         #{memberId},
         #{weeklyTotalAmount},
+        #{weeklyValuationTotal},
         #{weeklyTotalCount},
         <choose>
             <when test="createdAt != null">

--- a/src/main/resources/mapper/WeeklyInvestSummaryMapper.xml
+++ b/src/main/resources/mapper/WeeklyInvestSummaryMapper.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="woojooin.planitbatch.domain.mapper.totalInvestAmount.WeeklyInvestSummaryMapper">
+
+    <!-- WeeklyInvestSummaryVo ResultMap -->
+    <resultMap id="WeeklyInvestSummaryVoResultMap" type="woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo">
+        <result property="memberId" column="member_id"/>
+        <result property="weeklyTotalAmount" column="weekly_total_amount"/>
+        <result property="weeklyTotalCount" column="weekly_total_count"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+        <result property="isDeleted" column="is_deleted"/>
+    </resultMap>
+
+    <!-- 주간 투자 집계 데이터 INSERT -->
+    <insert id="insert" parameterType="woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo">
+        INSERT INTO weekly_report (
+        member_id,
+        weekly_total_amount,
+        weekly_total_count,
+        created_at,
+        updated_at,
+        is_deleted
+        ) VALUES (
+        #{memberId},
+        #{weeklyTotalAmount},
+        #{weeklyTotalCount},
+        <choose>
+            <when test="createdAt != null">
+                #{createdAt}
+            </when>
+            <otherwise>
+                CURRENT_TIMESTAMP
+            </otherwise>
+        </choose>,
+        <choose>
+            <when test="updatedAt != null">
+                #{updatedAt}
+            </when>
+            <otherwise>
+                CURRENT_TIMESTAMP
+            </otherwise>
+        </choose>,
+        #{isDeleted}
+        )
+    </insert>
+
+    <!-- Batch INSERT (성능 최적화용) -->
+    <insert id="batchInsert">
+        INSERT INTO weekly_report (
+        member_id,
+        weekly_total_amount,
+        weekly_total_count,
+        created_at,
+        updated_at,
+        is_deleted
+        ) VALUES
+        <foreach collection="collection" item="item" separator=",">
+            (
+            #{item.memberId},
+            #{item.weeklyTotalAmount},
+            #{item.weeklyTotalCount},
+            #{item.createdAt},
+            #{item.updatedAt},
+            #{item.isDeleted}
+            )
+        </foreach>
+    </insert>
+
+
+</mapper>

--- a/src/main/resources/mapper/WeeklyReportMapper.xml
+++ b/src/main/resources/mapper/WeeklyReportMapper.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="woojooin.planitbatch.domain.mapper.totalInvestAmount.WeeklyReportMapper">
+
+    <!-- WeeklyInvestSummaryVo ResultMap -->
+    <resultMap id="WeeklyInvestSummaryVoResultMap" type="woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo">
+        <result property="memberId" column="member_id"/>
+        <result property="weeklyTotalAmount" column="weekly_total_amount"/>
+        <result property="weeklyTotalCount" column="weekly_total_count"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="updatedAt" column="updated_at"/>
+        <result property="isDeleted" column="is_deleted"/>
+    </resultMap>
+
+    <!-- 지난달 전체 주간 데이터 조회 (플랫 리스트) -->
+    <select id="selectWeeklyDataForMonth" resultMap="WeeklyInvestSummaryVoResultMap">
+        SELECT
+            member_id,
+            weekly_total_amount,
+            weekly_total_count,
+            created_at,
+            updated_at,
+            is_deleted
+        FROM weekly_report
+        WHERE DATE(created_at) BETWEEN #{startDate} AND #{endDate}
+          AND is_deleted = 0
+          AND member_id IS NOT NULL
+          AND weekly_total_amount > 0
+        ORDER BY member_id, created_at
+    </select>
+
+    <!-- 지난달 주간 데이터가 있는 멤버 ID 리스트 조회 (페이징) -->
+    <select id="selectMemberIdsForMonth" resultType="Long">
+        SELECT DISTINCT member_id
+        FROM weekly_report
+        WHERE DATE(created_at) BETWEEN #{startDate} AND #{endDate}
+          AND is_deleted = 0
+          AND member_id IS NOT NULL
+          AND weekly_total_amount > 0
+        ORDER BY member_id
+            LIMIT #{_pagesize} OFFSET #{_skiprows}
+    </select>
+
+    <!-- 특정 멤버의 지난달 주간 데이터 조회 -->
+    <select id="selectMemberWeeklyDataForMonth" resultMap="WeeklyInvestSummaryVoResultMap">
+        SELECT
+            member_id,
+            weekly_total_amount,
+            weekly_total_count,
+            created_at,
+            updated_at,
+            is_deleted
+        FROM weekly_report
+        WHERE member_id = #{memberId}
+          AND DATE(created_at) BETWEEN #{startDate} AND #{endDate}
+          AND is_deleted = 0
+          AND weekly_total_amount > 0
+        ORDER BY created_at
+    </select>
+
+    <!-- 지난달 주간 데이터가 있는 멤버 수 조회 -->
+    <select id="countMembersWithDataForMonth" resultType="int">
+        SELECT COUNT(DISTINCT member_id)
+        FROM weekly_report
+        WHERE DATE(created_at) BETWEEN #{startDate} AND #{endDate}
+          AND is_deleted = 0
+          AND member_id IS NOT NULL
+          AND weekly_total_amount > 0
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/WeeklyReportMapper.xml
+++ b/src/main/resources/mapper/WeeklyReportMapper.xml
@@ -7,6 +7,7 @@
     <resultMap id="WeeklyInvestSummaryVoResultMap" type="woojooin.planitbatch.domain.vo.totalInvestAmountVo.WeeklyInvestSummaryVo">
         <result property="memberId" column="member_id"/>
         <result property="weeklyTotalAmount" column="weekly_total_amount"/>
+        <result property="weeklyValuationTotal" column="weekly_valuation_total"/>
         <result property="weeklyTotalCount" column="weekly_total_count"/>
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
@@ -18,6 +19,7 @@
         SELECT
             member_id,
             weekly_total_amount,
+            weekly_valuation_total,
             weekly_total_count,
             created_at,
             updated_at,
@@ -47,6 +49,7 @@
         SELECT
             member_id,
             weekly_total_amount,
+            weekly_valuation_total,
             weekly_total_count,
             created_at,
             updated_at,


### PR DESCRIPTION
🔖 PR 유형
 ✨ 기능 추가
 🐛 버그 수정
 ♻️ 리팩토링
 🧪 테스트 코드 추가
 📄 문서 수정
 기타

📌 개요
투자금 총액을 일별, 주별, 월별로 집계하는 Spring Batch 시스템을 구현했습니다.
각 배치는 하위 단위 데이터를 읽어서 상위 단위로 집계하여 저장하는 구조로 설계되었습니다.

🔧 작업 내용
📊 배치 구조
Daily Batch: 개별 투자 데이터 → 일별 집계
Weekly Batch: 일별 집계 데이터 → 주별 집계 (지난주 기준)
Monthly Batch: 주별 집계 데이터 → 월별 집계 (지난달 기준)

🔄 Weekly Batch 구현
Reader: WeeklyInvestAmountReader
지난주(월~일) 기간의 일별 데이터를 멤버별로 그룹핑하여 읽기
페이징 처리 (1000명 단위)
메모리 최적화를 위한 배치 단위 처리

Processor: WeeklyInvestAmountProcessor
멤버별 일별 데이터를 주간 합계로 집계
투자금액/건수 합산 및 검증 로직

Writer: MyBatis 기반 배치 삽입

🔄 Monthly Batch 구현
Reader: MonthlyReportAmountReader
지난달(1일~말일) 기간의 주별 데이터를 멤버별로 그룹핑하여 읽기
페이징 처리 및 메모리 관리

Processor: MonthlyInvestAmountProcessor
멤버별 주별 데이터를 월간 합계로 집계
월간 총액/건수, 투자 주차수, 주당 평균 계산

Writer: MyBatis 기반 배치 삽입

🗄️ 데이터베이스 설계
weekly_invest_summary: 주간 집계 테이블
member_id, weekly_total_amount, weekly_total_count

monthly_report: 월간 집계 테이블
member_id, monthly_total_amount, monthly_total_count, week_count, avg_weekly_amount, avg_weekly_count

📝 MyBatis 매퍼 구현
WeeklyReportMapper: 주별 데이터 조회용
멤버별 페이징 조회, 기간별 필터링

MonthlyInvestSummaryMapper: 월별 데이터 저장용
단건/배치 삽입, 기간별 조회

✅ 체크리스트
 테스트 완료(Postman, Swagger)
📝 기타 참고 사항
주의할 점, 추후 리팩토링 필요성 등
📎 관련 이슈
Close #이슈번호